### PR TITLE
Add token expiration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@croct/plug": "^0.14.1",
         "@croct/plug-react": "^0.7.1",
-        "@croct/sdk": "^0.16.0",
+        "@croct/sdk": "^0.16.1",
         "cookie": "^0.6.0",
         "server-only": "^0.0.1",
         "uuid": "^9.0.1"
@@ -2192,9 +2192,9 @@
       }
     },
     "node_modules/@croct/sdk": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@croct/sdk/-/sdk-0.16.0.tgz",
-      "integrity": "sha512-mi2qzp08LtPD5giJIrUDCEFU3Ee3AL9BFCGfdszgO8k8TBmeitQUVnqsOZXPA8nG32jtt+WaZmFTp7Ewo1BTww==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@croct/sdk/-/sdk-0.16.1.tgz",
+      "integrity": "sha512-QsK++RjK2j/sm60ZWRnPVpJR5ZI+vX3dphns7E6KG1iJ5JkcdvlOftZmZAfxnJvtjwIa2U7Rzz/0qL3NwJwafw==",
       "dependencies": {
         "@croct/json": "^2.0.1",
         "tslib": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@croct/plug": "^0.14.1",
     "@croct/plug-react": "^0.7.1",
-    "@croct/sdk": "^0.16.0",
+    "@croct/sdk": "^0.16.1",
     "cookie": "^0.6.0",
     "server-only": "^0.0.1",
     "uuid": "^9.0.1"

--- a/src/config/security.test.ts
+++ b/src/config/security.test.ts
@@ -13,6 +13,8 @@ describe('security', () => {
     const privateKey = 'ES256;MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg3TbbvRM7DNwxY3XGWDmlSRPSfZ9b+ch9TO3jQ6'
         + '8Zyj+hRANCAASmJj/EiEhUaLAWnbXMTb/85WADkuFgoELGZ5ByV7YPlbb2wY6oLjzGkpF6z8iDrvJ4kV6EhaJ4n0HwSQckVLNE';
 
+    const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
     describe('getApiKey', () => {
         beforeEach(() => {
             delete process.env.CROCT_API_KEY;
@@ -198,7 +200,7 @@ describe('security', () => {
                 iss: 'croct.io',
                 aud: 'croct.io',
                 sub: userId,
-                jti: expect.stringMatching(/^[a-f0-9-]{36}$/),
+                jti: expect.stringMatching(UUID_PATTERN),
             });
 
             const [header, payload, signature] = token.toString().split('.');
@@ -250,6 +252,7 @@ describe('security', () => {
                 iss: 'croct.io',
                 aud: 'croct.io',
                 sub: userId,
+                jti: expect.stringMatching(UUID_PATTERN),
             });
         });
     });

--- a/src/config/security.test.ts
+++ b/src/config/security.test.ts
@@ -13,6 +13,8 @@ describe('security', () => {
     const privateKey = 'ES256;MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg3TbbvRM7DNwxY3XGWDmlSRPSfZ9b+ch9TO3jQ6'
         + '8Zyj+hRANCAASmJj/EiEhUaLAWnbXMTb/85WADkuFgoELGZ5ByV7YPlbb2wY6oLjzGkpF6z8iDrvJ4kV6EhaJ4n0HwSQckVLNE';
 
+    const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
     describe('getApiKey', () => {
         beforeEach(() => {
             delete process.env.CROCT_API_KEY;
@@ -198,7 +200,7 @@ describe('security', () => {
                 iss: 'croct.io',
                 aud: 'croct.io',
                 sub: userId,
-                jti: expect.stringMatching(/^[a-f0-9-]{36}$/),
+                jti: expect.stringMatching(UUID_PATTERN),
             });
 
             const [header, payload, signature] = token.toString().split('.');

--- a/src/config/security.test.ts
+++ b/src/config/security.test.ts
@@ -13,8 +13,6 @@ describe('security', () => {
     const privateKey = 'ES256;MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg3TbbvRM7DNwxY3XGWDmlSRPSfZ9b+ch9TO3jQ6'
         + '8Zyj+hRANCAASmJj/EiEhUaLAWnbXMTb/85WADkuFgoELGZ5ByV7YPlbb2wY6oLjzGkpF6z8iDrvJ4kV6EhaJ4n0HwSQckVLNE';
 
-    const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-
     describe('getApiKey', () => {
         beforeEach(() => {
             delete process.env.CROCT_API_KEY;
@@ -200,7 +198,7 @@ describe('security', () => {
                 iss: 'croct.io',
                 aud: 'croct.io',
                 sub: userId,
-                jti: expect.stringMatching(UUID_PATTERN),
+                jti: expect.stringMatching(/^[a-f0-9-]{36}$/),
             });
 
             const [header, payload, signature] = token.toString().split('.');
@@ -252,7 +250,6 @@ describe('security', () => {
                 iss: 'croct.io',
                 aud: 'croct.io',
                 sub: userId,
-                jti: expect.stringMatching(UUID_PATTERN),
             });
         });
     });

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -54,11 +54,11 @@ export function getTokenDuration(): number {
 
 export function issueToken(userId: string|null = null): Promise<Token> {
     const token = Token.issue(getAppId(), userId)
+        .withTokenId(uuid())
         .withDuration(getTokenDuration());
 
     if (isUserTokenAuthenticationEnabled()) {
-        return token.withTokenId(uuid())
-            .signedWith(getAuthenticationKey());
+        return token.signedWith(getAuthenticationKey());
     }
 
     return Promise.resolve(token);

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -54,11 +54,11 @@ export function getTokenDuration(): number {
 
 export function issueToken(userId: string|null = null): Promise<Token> {
     const token = Token.issue(getAppId(), userId)
-        .withTokenId(uuid())
         .withDuration(getTokenDuration());
 
     if (isUserTokenAuthenticationEnabled()) {
-        return token.signedWith(getAuthenticationKey());
+        return token.withTokenId(uuid())
+            .signedWith(getAuthenticationKey());
     }
 
     return Promise.resolve(token);

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -576,7 +576,7 @@ describe('middleware', () => {
 
         expect(parsedToken.isAnonymous()).toBe(true);
         expect(parsedToken.getApplicationId()).toBe(getAppId());
-        expect(parsedToken.getTokenId()).toEqual(expect.stringMatching(UUID_PATTERN));
+        expect(parsedToken.getTokenId()).toBeNull();
 
         expect(parseSetCookies(response.headers.getSetCookie())).toIncludeAllMembers([{
             ...scenario.cookie,

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -576,7 +576,7 @@ describe('middleware', () => {
 
         expect(parsedToken.isAnonymous()).toBe(true);
         expect(parsedToken.getApplicationId()).toBe(getAppId());
-        expect(parsedToken.getTokenId()).toBeNull();
+        expect(parsedToken.getTokenId()).toEqual(expect.stringMatching(UUID_PATTERN));
 
         expect(parseSetCookies(response.headers.getSetCookie())).toIncludeAllMembers([{
             ...scenario.cookie,

--- a/src/server/anonymize.test.ts
+++ b/src/server/anonymize.test.ts
@@ -1,39 +1,14 @@
-import {ApiKey as MockApiKey} from '@croct/sdk/apiKey';
 import {cookies} from 'next/headers';
 import {Token} from '@croct/sdk/token';
-import {getAppId} from '@/config/appId';
-import {getAuthenticationKey, isUserTokenAuthenticationEnabled} from '@/config/security';
+import {issueToken} from '@/config/security';
 import {anonymize} from '@/server/anonymize';
 
 jest.mock(
-    'uuid',
-    () => ({
-        v4: jest.fn(() => '00000000-0000-0000-0000-000000000000'),
-    }),
-);
-
-jest.mock(
     '@/config/security',
-    () => {
-        const identifier = '00000000-0000-0000-0000-000000000000';
-        const apiKey = MockApiKey.of(identifier);
-
-        return {
-            __esModule: true,
-            ...jest.requireActual('@/config/security'),
-            getApiKey: jest.fn(() => apiKey),
-            getAuthenticationKey: jest.fn(() => apiKey),
-            isUserTokenAuthenticationEnabled: jest.fn(() => false),
-        };
-    },
-);
-
-jest.mock(
-    '@/config/appId',
     () => ({
         __esModule: true,
-        ...jest.requireActual('@/config/appId'),
-        getAppId: jest.fn(() => '00000000-0000-0000-0000-000000000000'),
+        ...jest.requireActual('@/config/security'),
+        issueToken: jest.fn(),
     }),
 );
 
@@ -73,16 +48,12 @@ jest.mock(
 describe('anonymize', () => {
     afterEach(() => {
         jest.mocked(cookies().set).mockClear();
-        jest.mocked(isUserTokenAuthenticationEnabled).mockReset();
-        jest.useRealTimers();
     });
 
-    it('should set a unsigned token in the cookie', async () => {
-        jest.useFakeTimers({now: Date.now()});
+    it('should set a token in the cookie', async () => {
+        const token = Token.issue('00000000-0000-0000-0000-000000000001');
 
-        jest.mocked(isUserTokenAuthenticationEnabled).mockReturnValue(false);
-
-        expect(isUserTokenAuthenticationEnabled()).toBe(false);
+        jest.mocked(issueToken).mockResolvedValue(token);
 
         await expect(anonymize()).resolves.toBeUndefined();
 
@@ -95,62 +66,7 @@ describe('anonymize', () => {
             domain: undefined,
             secure: false,
             sameSite: 'lax',
-            value: Token.issue(getAppId()).toString(),
+            value: token.toString(),
         });
-    });
-
-    it('should set a signed token in the cookie', async () => {
-        jest.useFakeTimers({now: Date.now()});
-
-        const keyPair = await crypto.subtle.generateKey(
-            {
-                name: 'ECDSA',
-                namedCurve: 'P-256',
-            },
-            true,
-            ['sign', 'verify'],
-        );
-
-        const exportedKey = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
-        const privateKey = Buffer.from(exportedKey).toString('base64');
-
-        const apiKey = MockApiKey.of('00000000-0000-0000-0000-000000000001', `ES256;${privateKey}`);
-
-        jest.mocked(getAuthenticationKey).mockReturnValue(apiKey);
-
-        jest.mocked(isUserTokenAuthenticationEnabled).mockReturnValue(true);
-
-        expect(isUserTokenAuthenticationEnabled()).toBe(true);
-
-        await expect(anonymize()).resolves.toBeUndefined();
-
-        const jar = cookies();
-
-        expect(jar.set).toHaveBeenCalledWith({
-            name: 'croct',
-            maxAge: 86400,
-            path: '/',
-            domain: undefined,
-            secure: false,
-            sameSite: 'lax',
-            value: expect.toBeString(),
-        });
-
-        const {value: cookieValue} = jest.mocked(jar.set).mock.calls[0][0] as {value: string};
-        const [header, payload, signature] = cookieValue.split('.');
-
-        const verification = crypto.subtle.verify(
-            {
-                name: 'ECDSA',
-                hash: {
-                    name: 'SHA-256',
-                },
-            },
-            keyPair.publicKey,
-            Buffer.from(signature, 'base64url'),
-            Buffer.from(`${header}.${payload}`),
-        );
-
-        await expect(verification).resolves.toBeTrue();
     });
 });

--- a/src/server/anonymize.ts
+++ b/src/server/anonymize.ts
@@ -1,17 +1,9 @@
 import {cookies} from 'next/headers';
-import {Token} from '@croct/sdk/token';
-import {v4 as uuid} from 'uuid';
 import {getUserTokenCookieOptions} from '@/config/cookie';
-import {getAuthenticationKey, isUserTokenAuthenticationEnabled} from '@/config/security';
-import {getAppId} from '@/config/appId';
+import {issueToken} from '@/config/security';
 
 export async function anonymize(): Promise<void> {
-    const token = isUserTokenAuthenticationEnabled()
-        ? await Token.issue(getAppId())
-            .withTokenId(uuid())
-            .signedWith(getAuthenticationKey())
-        : Token.issue(getAppId());
-
+    const token = await issueToken();
     const jar = cookies();
     const cookieOptions = getUserTokenCookieOptions();
 

--- a/src/server/identify.test.ts
+++ b/src/server/identify.test.ts
@@ -1,39 +1,14 @@
-import {ApiKey as MockApiKey} from '@croct/sdk/apiKey';
 import {cookies} from 'next/headers';
 import {Token} from '@croct/sdk/token';
+import {issueToken} from '@/config/security';
 import {identify} from '@/server/identify';
-import {getAppId} from '@/config/appId';
-import {getAuthenticationKey, isUserTokenAuthenticationEnabled} from '@/config/security';
-
-jest.mock(
-    'uuid',
-    () => ({
-        v4: jest.fn(() => '00000000-0000-0000-0000-000000000000'),
-    }),
-);
 
 jest.mock(
     '@/config/security',
-    () => {
-        const identifier = '00000000-0000-0000-0000-000000000000';
-        const apiKey = MockApiKey.of(identifier);
-
-        return {
-            __esModule: true,
-            ...jest.requireActual('@/config/security'),
-            getApiKey: jest.fn(() => apiKey),
-            getAuthenticationKey: jest.fn(() => apiKey),
-            isUserTokenAuthenticationEnabled: jest.fn(() => false),
-        };
-    },
-);
-
-jest.mock(
-    '@/config/appId',
     () => ({
         __esModule: true,
-        ...jest.requireActual('@/config/appId'),
-        getAppId: jest.fn(() => '00000000-0000-0000-0000-000000000000'),
+        ...jest.requireActual('@/config/security'),
+        issueToken: jest.fn(),
     }),
 );
 
@@ -73,20 +48,17 @@ jest.mock(
 describe('identify', () => {
     afterEach(() => {
         jest.mocked(cookies().set).mockClear();
-        jest.mocked(isUserTokenAuthenticationEnabled).mockReset();
-        jest.useRealTimers();
     });
 
-    it('should set a unsigned token in the cookie', async () => {
-        jest.useFakeTimers({now: Date.now()});
+    it('should set a token in the cookie', async () => {
+        const userId = 'user-id';
+        const token = Token.issue('00000000-0000-0000-0000-000000000001', userId);
 
-        const userId = 'test';
-
-        jest.mocked(isUserTokenAuthenticationEnabled).mockReturnValue(false);
-
-        expect(isUserTokenAuthenticationEnabled()).toBe(false);
+        jest.mocked(issueToken).mockResolvedValue(token);
 
         await expect(identify(userId)).resolves.toBeUndefined();
+
+        expect(issueToken).toHaveBeenCalledWith(userId);
 
         const jar = cookies();
 
@@ -97,63 +69,7 @@ describe('identify', () => {
             domain: undefined,
             secure: false,
             sameSite: 'lax',
-            value: Token.issue(getAppId(), userId).toString(),
+            value: token.toString(),
         });
-    });
-
-    it('should set a signed token in the cookie', async () => {
-        jest.useFakeTimers({now: Date.now()});
-        const userId = 'test';
-
-        const keyPair = await crypto.subtle.generateKey(
-            {
-                name: 'ECDSA',
-                namedCurve: 'P-256',
-            },
-            true,
-            ['sign', 'verify'],
-        );
-
-        const exportedKey = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
-        const privateKey = Buffer.from(exportedKey).toString('base64');
-
-        const apiKey = MockApiKey.of('00000000-0000-0000-0000-000000000001', `ES256;${privateKey}`);
-
-        jest.mocked(getAuthenticationKey).mockReturnValue(apiKey);
-
-        jest.mocked(isUserTokenAuthenticationEnabled).mockReturnValue(true);
-
-        expect(isUserTokenAuthenticationEnabled()).toBe(true);
-
-        await expect(identify(userId)).resolves.toBeUndefined();
-
-        const jar = cookies();
-
-        expect(jar.set).toHaveBeenCalledWith({
-            name: 'croct',
-            maxAge: 86400,
-            path: '/',
-            domain: undefined,
-            secure: false,
-            sameSite: 'lax',
-            value: expect.toBeString(),
-        });
-
-        const {value: cookieValue} = jest.mocked(jar.set).mock.calls[0][0] as {value: string};
-        const [header, payload, signature] = cookieValue.split('.');
-
-        const verification = crypto.subtle.verify(
-            {
-                name: 'ECDSA',
-                hash: {
-                    name: 'SHA-256',
-                },
-            },
-            keyPair.publicKey,
-            Buffer.from(signature, 'base64url'),
-            Buffer.from(`${header}.${payload}`),
-        );
-
-        await expect(verification).resolves.toBeTrue();
     });
 });

--- a/src/server/identify.ts
+++ b/src/server/identify.ts
@@ -1,17 +1,9 @@
 import {cookies} from 'next/headers';
-import {Token} from '@croct/sdk/token';
-import {v4 as uuid} from 'uuid';
-import {getAppId} from '@/config/appId';
-import {getAuthenticationKey, isUserTokenAuthenticationEnabled} from '@/config/security';
+import {issueToken} from '@/config/security';
 import {getUserTokenCookieOptions} from '@/config/cookie';
 
 export async function identify(userId: string): Promise<void> {
-    const token = isUserTokenAuthenticationEnabled()
-        ? await Token.issue(getAppId(), userId)
-            .withTokenId(uuid())
-            .signedWith(getAuthenticationKey())
-        : Token.issue(getAppId(), userId);
-
+    const token = await issueToken(userId);
     const jar = cookies();
     const cookieOptions = getUserTokenCookieOptions();
 


### PR DESCRIPTION
## Summary
This pull request adds support for specifying the duration of tokens. By default, it is set to 24 hours. It also modifies the token-issuing logic to include an ID in all tokens.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings