### PR TITLE
Change sameSite to none by default

### DIFF
--- a/src/config/cookie.test.ts
+++ b/src/config/cookie.test.ts
@@ -1,3 +1,4 @@
+import * as process from 'node:process';
 import {getClientIdCookieOptions, getPreviewCookieOptions, getUserTokenCookieOptions} from '@/config/cookie';
 
 describe('cookie', () => {
@@ -6,16 +7,32 @@ describe('cookie', () => {
             delete process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_DURATION;
             delete process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_DOMAIN;
             delete process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_NAME;
+
+            process.env.NODE_ENV = 'production';
         });
 
-        it('should return default options', () => {
-            expect(getClientIdCookieOptions()).toEqual({
-                name: 'ct.client_id',
-                maxAge: 31536000,
-                secure: true,
-                path: '/',
-                sameSite: 'none',
-            });
+        it.each([
+            'production',
+            'development',
+            'test',
+        ])('should return default options for %s environment', env => {
+            process.env.NODE_ENV = env;
+
+            expect(getClientIdCookieOptions()).toEqual(
+                env === 'production'
+                    ? {
+                        name: 'ct.client_id',
+                        maxAge: 31536000,
+                        path: '/',
+                        secure: true,
+                        sameSite: 'none',
+                    }
+                    : {
+                        name: 'ct.client_id',
+                        maxAge: 31536000,
+                        path: '/',
+                    },
+            );
         });
 
         it('should return default options for empty values', () => {
@@ -116,8 +133,8 @@ describe('cookie', () => {
             expect(getUserTokenCookieOptions()).toEqual({
                 name: 'ct.user_token',
                 maxAge: 604800,
-                secure: true,
                 path: '/',
+                secure: true,
                 sameSite: 'none',
             });
         });
@@ -130,8 +147,8 @@ describe('cookie', () => {
             expect(getUserTokenCookieOptions()).toEqual({
                 name: 'ct.user_token',
                 maxAge: 604800,
-                secure: true,
                 path: '/',
+                secure: true,
                 sameSite: 'none',
             });
         });
@@ -144,10 +161,10 @@ describe('cookie', () => {
             expect(getUserTokenCookieOptions()).toEqual({
                 name: process.env.NEXT_PUBLIC_CROCT_USER_TOKEN_COOKIE_NAME,
                 maxAge: Number.parseInt(process.env.NEXT_PUBLIC_CROCT_USER_TOKEN_COOKIE_DURATION, 10),
-                secure: true,
                 path: '/',
-                sameSite: 'none',
                 domain: process.env.NEXT_PUBLIC_CROCT_USER_TOKEN_COOKIE_DOMAIN,
+                secure: true,
+                sameSite: 'none',
             });
         });
 

--- a/src/config/cookie.test.ts
+++ b/src/config/cookie.test.ts
@@ -14,7 +14,7 @@ describe('cookie', () => {
                 maxAge: 31536000,
                 secure: true,
                 path: '/',
-                sameSite: 'strict',
+                sameSite: 'none',
             });
         });
 
@@ -28,7 +28,7 @@ describe('cookie', () => {
                 maxAge: 31536000,
                 secure: true,
                 path: '/',
-                sameSite: 'strict',
+                sameSite: 'none',
             });
         });
 
@@ -42,7 +42,7 @@ describe('cookie', () => {
                 maxAge: Number.parseInt(process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_DURATION, 10),
                 secure: true,
                 path: '/',
-                sameSite: 'strict',
+                sameSite: 'none',
                 domain: process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_DOMAIN,
             });
         });
@@ -76,7 +76,7 @@ describe('cookie', () => {
                 name: 'ct.preview_token',
                 path: '/',
                 secure: true,
-                sameSite: 'strict',
+                sameSite: 'none',
             });
         });
 
@@ -87,7 +87,7 @@ describe('cookie', () => {
                 name: 'ct.preview_token',
                 path: '/',
                 secure: true,
-                sameSite: 'strict',
+                sameSite: 'none',
             });
         });
 
@@ -100,7 +100,7 @@ describe('cookie', () => {
                 path: '/',
                 domain: process.env.NEXT_PUBLIC_CROCT_PREVIEW_TOKEN_COOKIE_DOMAIN,
                 secure: true,
-                sameSite: 'strict',
+                sameSite: 'none',
             });
         });
     });
@@ -118,7 +118,7 @@ describe('cookie', () => {
                 maxAge: 604800,
                 secure: true,
                 path: '/',
-                sameSite: 'strict',
+                sameSite: 'none',
             });
         });
 
@@ -132,7 +132,7 @@ describe('cookie', () => {
                 maxAge: 604800,
                 secure: true,
                 path: '/',
-                sameSite: 'strict',
+                sameSite: 'none',
             });
         });
 
@@ -146,7 +146,7 @@ describe('cookie', () => {
                 maxAge: Number.parseInt(process.env.NEXT_PUBLIC_CROCT_USER_TOKEN_COOKIE_DURATION, 10),
                 secure: true,
                 path: '/',
-                sameSite: 'strict',
+                sameSite: 'none',
                 domain: process.env.NEXT_PUBLIC_CROCT_USER_TOKEN_COOKIE_DOMAIN,
             });
         });

--- a/src/config/cookie.test.ts
+++ b/src/config/cookie.test.ts
@@ -1,4 +1,3 @@
-import * as process from 'node:process';
 import {getClientIdCookieOptions, getPreviewCookieOptions, getUserTokenCookieOptions} from '@/config/cookie';
 
 describe('cookie', () => {

--- a/src/config/cookie.ts
+++ b/src/config/cookie.ts
@@ -26,7 +26,7 @@ export function getClientIdCookieOptions(): CookieOptions {
         maxAge: parsedDuration,
         secure: true,
         path: '/',
-        sameSite: 'strict',
+        sameSite: 'none',
         ...(domain !== '' ? {domain: domain} : {}),
     };
 }
@@ -49,7 +49,7 @@ export function getUserTokenCookieOptions(): CookieOptions {
         maxAge: parsedDuration,
         secure: true,
         path: '/',
-        sameSite: 'strict',
+        sameSite: 'none',
         ...(domain !== '' ? {domain: domain} : {}),
     };
 }
@@ -61,7 +61,7 @@ export function getPreviewCookieOptions(): CookieOptions {
         name: normalizeValue(process.env.NEXT_PUBLIC_CROCT_PREVIEW_TOKEN_COOKIE_NAME, 'ct.preview_token'),
         secure: true,
         path: '/',
-        sameSite: 'strict',
+        sameSite: 'none',
         ...(domain !== '' ? {domain: domain} : {}),
     };
 }

--- a/src/config/cookie.ts
+++ b/src/config/cookie.ts
@@ -24,10 +24,9 @@ export function getClientIdCookieOptions(): CookieOptions {
     return {
         name: normalizeValue(process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_NAME, 'ct.client_id'),
         maxAge: parsedDuration,
-        secure: true,
         path: '/',
-        sameSite: 'none',
         ...(domain !== '' ? {domain: domain} : {}),
+        ...getEnvOptions(),
     };
 }
 
@@ -47,10 +46,9 @@ export function getUserTokenCookieOptions(): CookieOptions {
     return {
         name: normalizeValue(process.env.NEXT_PUBLIC_CROCT_USER_TOKEN_COOKIE_NAME, 'ct.user_token'),
         maxAge: parsedDuration,
-        secure: true,
         path: '/',
-        sameSite: 'none',
         ...(domain !== '' ? {domain: domain} : {}),
+        ...getEnvOptions(),
     };
 }
 
@@ -59,10 +57,20 @@ export function getPreviewCookieOptions(): CookieOptions {
 
     return {
         name: normalizeValue(process.env.NEXT_PUBLIC_CROCT_PREVIEW_TOKEN_COOKIE_NAME, 'ct.preview_token'),
-        secure: true,
         path: '/',
-        sameSite: 'none',
         ...(domain !== '' ? {domain: domain} : {}),
+        ...getEnvOptions(),
+    };
+}
+
+function getEnvOptions(): Partial<CookieOptions> {
+    if (process.env.NODE_ENV !== 'production') {
+        return {};
+    }
+
+    return {
+        secure: true,
+        sameSite: 'none',
     };
 }
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -163,7 +163,7 @@ describe('middleware', () => {
                 name: 'ct.client_id',
                 secure: true,
                 path: '/',
-                sameSite: 'Strict',
+                sameSite: 'None',
                 maxAge: 31536000,
             },
         },
@@ -177,7 +177,7 @@ describe('middleware', () => {
                 name: 'ct.client_id',
                 secure: true,
                 path: '/',
-                sameSite: 'Strict',
+                sameSite: 'None',
                 maxAge: 31536000,
             },
         },
@@ -193,12 +193,12 @@ describe('middleware', () => {
                 name: 'custom_cid',
                 secure: true,
                 path: '/',
-                sameSite: 'Strict',
+                sameSite: 'None',
                 maxAge: 60,
                 domain: 'croct.com',
             },
         },
-    }))('should assign a new client ID if none is present with %s', async (_, scenario) => {
+    }))('should assign a new client ID if None is present with %s', async (_, scenario) => {
         const request = createRequestMock();
         const response = createResponseMock();
 
@@ -298,7 +298,7 @@ describe('middleware', () => {
             maxAge: 31536000,
             secure: true,
             path: '/',
-            sameSite: 'Strict',
+            sameSite: 'None',
             value: clientId,
         }]);
     });
@@ -328,7 +328,7 @@ describe('middleware', () => {
             maxAge: 31536000,
             secure: true,
             path: '/',
-            sameSite: 'Strict',
+            sameSite: 'None',
             value: clientId,
         }]);
     });
@@ -402,7 +402,7 @@ describe('middleware', () => {
         expect(parseSetCookies(response.headers.getSetCookie())).toIncludeAllMembers([{
             name: cookieName,
             path: '/',
-            sameSite: 'Strict',
+            sameSite: 'None',
             secure: true,
             value: previewToken,
         }]);
@@ -525,7 +525,7 @@ describe('middleware', () => {
                 name: 'ct.user_token',
                 secure: true,
                 path: '/',
-                sameSite: 'Strict',
+                sameSite: 'None',
                 maxAge: 604800,
             },
         },
@@ -539,7 +539,7 @@ describe('middleware', () => {
                 name: 'ct.user_token',
                 secure: true,
                 path: '/',
-                sameSite: 'Strict',
+                sameSite: 'None',
                 maxAge: 604800,
             },
         },
@@ -553,12 +553,12 @@ describe('middleware', () => {
                 name: 'custom_ut',
                 secure: true,
                 path: '/',
-                sameSite: 'Strict',
+                sameSite: 'None',
                 maxAge: 60,
                 domain: 'croct.com',
             },
         },
-    }))('should assign a new user token if none is present with %s', async (_, scenario) => {
+    }))('should assign a new user token if None is present with %s', async (_, scenario) => {
         const request = createRequestMock();
         const response = createResponseMock();
 
@@ -610,7 +610,7 @@ describe('middleware', () => {
             maxAge: 604800,
             secure: true,
             path: '/',
-            sameSite: 'Strict',
+            sameSite: 'None',
             value: userToken,
         }]);
     });
@@ -948,7 +948,7 @@ describe('middleware', () => {
                 {
                     typ: 'JWT',
                     appId: getAppId(),
-                    alg: 'none',
+                    alg: 'None',
                 },
                 {
                     exp: requestToken.expiration,
@@ -997,7 +997,7 @@ describe('middleware', () => {
             maxAge: 604800,
             secure: true,
             path: '/',
-            sameSite: 'Strict',
+            sameSite: 'None',
             value: newUserToken,
         }]);
     });

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -135,6 +135,7 @@ describe('middleware', () => {
         delete process.env.CROCT_DISABLE_USER_TOKEN_AUTHENTICATION;
 
         process.env.NEXT_PUBLIC_CROCT_APP_ID = '00000000-0000-0000-0000-000000000000';
+        process.env.NODE_ENV = 'production';
     });
 
     afterEach(() => {
@@ -198,7 +199,7 @@ describe('middleware', () => {
                 domain: 'croct.com',
             },
         },
-    }))('should assign a new client ID if None is present with %s', async (_, scenario) => {
+    }))('should assign a new client ID if none is present with %s', async (_, scenario) => {
         const request = createRequestMock();
         const response = createResponseMock();
 
@@ -558,7 +559,7 @@ describe('middleware', () => {
                 domain: 'croct.com',
             },
         },
-    }))('should assign a new user token if None is present with %s', async (_, scenario) => {
+    }))('should assign a new user token if none is present with %s', async (_, scenario) => {
         const request = createRequestMock();
         const response = createResponseMock();
 
@@ -948,7 +949,7 @@ describe('middleware', () => {
                 {
                     typ: 'JWT',
                     appId: getAppId(),
-                    alg: 'None',
+                    alg: 'none',
                 },
                 {
                     exp: requestToken.expiration,


### PR DESCRIPTION
## Summary
This PR changes the cookies to use a `sameSite` from `strict` to `none` as it currently causes regeneration of client IDs for users accessing the application from external domains, which also affects the preview link.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings