### PR TITLE
Add support for page router

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,48 @@
+name: PR preview
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: |-
+          npm ci
+          rm -rf ~/.npmrc
+
+      - name: Build package
+        run: npm run build
+
+      - name: Prepare release
+        run: |-
+          cp package.json LICENSE README.md build/
+          cd build
+          find . -type f -path '*/*\.js.map' -exec sed -i -e "s~../src~src~" {} +
+          sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json
+          sed -i -e "s~\./build~.~" package.json
+          sed -i -e "s~./src~.~" package.json
+          cp -r ../src src
+
+      - name: Publish preview
+        run: |-
+          npx pkg-pr-new publish \
+            --compact --comment=update \
+            ./build

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@croct/plug-react": "^0.7.2",
         "@croct/sdk": "^0.16.2",
         "cookie": "^0.6.0",
-        "server-only": "^0.0.1",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -12644,12 +12643,6 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
-    },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
-      "license": "MIT"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@croct/plug-react": "^0.7.2",
     "@croct/sdk": "^0.16.2",
     "cookie": "^0.6.0",
-    "server-only": "^0.0.1",
     "uuid": "^10.0.0"
   },
   "devDependencies": {

--- a/src/config/context.test.ts
+++ b/src/config/context.test.ts
@@ -1,31 +1,40 @@
 import type {cookies} from 'next/headers';
 import {Token} from '@croct/sdk/token';
-import {getRequestContext, RequestContext} from '@/config/context';
+import {getRequestContext, RequestContext, resolveRequestContext} from '@/config/context';
 import {Header} from '@/config/http';
 import {getUserTokenCookieOptions} from '@/config/cookie';
+import {getCookies, getHeaders, PartialRequest, PartialResponse, RouteContext} from '@/headers';
 
 type ReadonlyCookies = ReturnType<typeof cookies>;
 
+function createCookieJar(cookies: Record<string, string> = {}): ReadonlyCookies {
+    const jar: Record<string, string> = {...cookies};
+
+    return {
+        get: jest.fn((name: string) => {
+            if (jar[name] === undefined) {
+                return undefined;
+            }
+
+            return {
+                name: name,
+                value: jar[name],
+            };
+        }),
+        has: jest.fn((name: string) => jar[name] !== undefined),
+    } as Partial<ReadonlyCookies> as ReadonlyCookies;
+}
+
+jest.mock(
+    '../headers',
+    () => ({
+        getCookies: jest.fn(),
+        getHeaders: jest.fn(),
+    }),
+);
+
 describe('getRequestContext', () => {
     const appId = '00000000-0000-0000-0000-000000000000';
-
-    function createCookieJar(cookies: Record<string, string> = {}): ReadonlyCookies {
-        const jar: Record<string, string> = {...cookies};
-
-        return {
-            get: jest.fn((name: string) => {
-                if (jar[name] === undefined) {
-                    return undefined;
-                }
-
-                return {
-                    name: name,
-                    value: jar[name],
-                };
-            }),
-            has: jest.fn((name: string) => jar[name] !== undefined),
-        } as Partial<ReadonlyCookies> as ReadonlyCookies;
-    }
 
     it('should throw an error when the client ID is missing', () => {
         expect(() => getRequestContext(new Headers(), createCookieJar()))
@@ -133,5 +142,41 @@ describe('getRequestContext', () => {
         const context = getRequestContext(headers, cookies);
 
         expect(context.userToken).toEqual(newToken.toString());
+    });
+});
+
+describe('resolveRequestContext', () => {
+    it('should return the request context', () => {
+        const headers = new Headers();
+        const cookies = createCookieJar();
+
+        const route: RouteContext = {
+            req: {} as PartialRequest,
+            res: {} as PartialResponse,
+        };
+
+        const request = {
+            clientId: '00000000-0000-0000-0000-000000000000',
+            uri: 'http://localhost:3000',
+            clientAgent: 'Mozilla/5.0',
+            referrer: 'http://referrer.com',
+            clientIp: '192.0.0.1',
+            previewToken: 'ct.preview_token',
+        } satisfies RequestContext;
+
+        headers.set(Header.CLIENT_ID, request.clientId);
+        headers.set(Header.REQUEST_URI, request.uri);
+        headers.set(Header.USER_AGENT, request.clientAgent);
+        headers.set(Header.REFERRER, request.referrer);
+        headers.set(Header.CLIENT_IP, request.clientIp);
+        headers.set(Header.PREVIEW_TOKEN, request.previewToken);
+
+        jest.mocked(getHeaders).mockReturnValue(headers);
+        jest.mocked(getCookies).mockReturnValue(cookies);
+
+        expect(resolveRequestContext(route)).toEqual(request);
+
+        expect(getHeaders).toHaveBeenCalledWith(route);
+        expect(getCookies).toHaveBeenCalledWith(route);
     });
 });

--- a/src/config/context.test.ts
+++ b/src/config/context.test.ts
@@ -4,13 +4,6 @@ import {getRequestContext, RequestContext} from '@/config/context';
 import {Header} from '@/config/http';
 import {getUserTokenCookieOptions} from '@/config/cookie';
 
-jest.mock(
-    'server-only',
-    () => ({
-        __esModule: true,
-    }),
-);
-
 type ReadonlyCookies = ReturnType<typeof cookies>;
 
 describe('getRequestContext', () => {

--- a/src/config/context.ts
+++ b/src/config/context.ts
@@ -1,7 +1,7 @@
 import {Token} from '@croct/sdk/token';
 import {Header} from '@/config/http';
 import {getUserTokenCookieOptions} from '@/config/cookie';
-import {CookieReader, HeaderReader} from '@/headers';
+import {CookieReader, getCookies, getHeaders, HeaderReader, RouteContext} from '@/headers';
 
 export type RequestContext = {
     clientId: string,
@@ -12,6 +12,10 @@ export type RequestContext = {
     userToken?: string,
     previewToken?: string,
 };
+
+export function resolveRequestContext(route?: RouteContext): RequestContext {
+    return getRequestContext(getHeaders(route), getCookies(route));
+}
 
 export function getRequestContext(headers: HeaderReader, cookies: CookieReader): RequestContext {
     const clientId = headers.get(Header.CLIENT_ID);

--- a/src/config/context.ts
+++ b/src/config/context.ts
@@ -1,10 +1,7 @@
-import type {cookies, headers} from 'next/headers';
 import {Token} from '@croct/sdk/token';
 import {Header} from '@/config/http';
 import {getUserTokenCookieOptions} from '@/config/cookie';
-
-type ReadonlyHeaders = ReturnType<typeof headers>;
-type ReadonlyCookies = ReturnType<typeof cookies>;
+import {CookieReader, HeaderReader} from '@/headers';
 
 export type RequestContext = {
     clientId: string,
@@ -16,7 +13,7 @@ export type RequestContext = {
     previewToken?: string,
 };
 
-export function getRequestContext(headers: ReadonlyHeaders, cookies: ReadonlyCookies): RequestContext {
+export function getRequestContext(headers: HeaderReader, cookies: CookieReader): RequestContext {
     const clientId = headers.get(Header.CLIENT_ID);
 
     if (clientId === null) {
@@ -75,7 +72,7 @@ export function getRequestContext(headers: ReadonlyHeaders, cookies: ReadonlyCoo
  * @param headers The request headers.
  * @param cookies The request cookies.
  */
-function getUserToken(headers: ReadonlyHeaders, cookies: ReadonlyCookies): string|null {
+function getUserToken(headers: HeaderReader, cookies: CookieReader): string|null {
     const {name: cookieName} = getUserTokenCookieOptions();
     const cookie = cookies.get(cookieName);
     const cookieValue = cookie === undefined || cookie.value === '' ? null : cookie.value;

--- a/src/config/cookie.test.ts
+++ b/src/config/cookie.test.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import {getClientIdCookieOptions, getPreviewCookieOptions, getUserTokenCookieOptions} from '@/config/cookie';
 
 describe('cookie', () => {
@@ -7,7 +8,7 @@ describe('cookie', () => {
             delete process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_DOMAIN;
             delete process.env.NEXT_PUBLIC_CROCT_CLIENT_ID_COOKIE_NAME;
 
-            process.env.NODE_ENV = 'production';
+            Object.assign(process.env, {NODE_ENV: 'production'});
         });
 
         it.each([
@@ -15,7 +16,7 @@ describe('cookie', () => {
             'development',
             'test',
         ])('should return default options for %s environment', env => {
-            process.env.NODE_ENV = env;
+            Object.assign(process.env, {NODE_ENV: env});
 
             expect(getClientIdCookieOptions()).toEqual(
                 env === 'production'

--- a/src/config/timeout.test.ts
+++ b/src/config/timeout.test.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import {getDefaultFetchTimeout} from '@/config/timeout';
 
 describe('getDefaultFetchTimeout', () => {
@@ -6,7 +7,7 @@ describe('getDefaultFetchTimeout', () => {
     beforeEach(() => {
         delete process.env.NEXT_PUBLIC_CROCT_DEFAULT_FETCH_TIMEOUT;
 
-        process.env.NODE_ENV = 'test';
+        Object.assign(process.env, {NODE_ENV: 'test'});
     });
 
     afterEach(() => {
@@ -18,7 +19,7 @@ describe('getDefaultFetchTimeout', () => {
     });
 
     it('should return the default value when the environment variable is missing and environment is production', () => {
-        process.env.NODE_ENV = 'production';
+        Object.assign(process.env, {NODE_ENV: 'production'});
 
         expect(getDefaultFetchTimeout()).toBe(2000);
     });

--- a/src/headers.test.ts
+++ b/src/headers.test.ts
@@ -38,7 +38,7 @@ describe('getHeaders', () => {
             throw new Error('next/headers requires app router');
         });
 
-        expect(() => getHeaders()).toThrow('No request context available');
+        expect(() => getHeaders()).toThrow('No route context found.');
     });
 
     type RequestContextScenario = {
@@ -142,7 +142,7 @@ describe('getCookies', () => {
             throw new Error('next/headers requires app router');
         });
 
-        expect(() => getCookies()).toThrow('No request context available');
+        expect(() => getCookies()).toThrow('No route context found.');
     });
 
     type RequestContextScenario = {

--- a/src/headers.test.ts
+++ b/src/headers.test.ts
@@ -1,0 +1,422 @@
+import {NextRequest, NextResponse} from 'next/server';
+import {NextApiRequest} from 'next';
+import {CookieOptions, getCookies, getHeaders, isAppRouter, PartialRequest, PartialResponse} from '@/headers';
+
+const mockHeaders = jest.fn();
+const mockCookies = jest.fn();
+
+jest.mock(
+    'next/headers',
+    () => ({
+        __esModule: true,
+        headers: mockHeaders,
+        cookies: mockCookies,
+    }),
+);
+
+describe('getHeaders', () => {
+    beforeEach(() => {
+        mockHeaders.mockReset();
+    });
+
+    it('should use next/headers if available', () => {
+        const get = jest.fn(() => 'test');
+
+        mockHeaders.mockReturnValue({
+            get: get,
+        });
+
+        const header = getHeaders();
+
+        expect(header.get('test')).toBe('test');
+
+        expect(get).toHaveBeenCalledWith('test');
+    });
+
+    it('should require the request context if next/headers is not available', () => {
+        mockHeaders.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        expect(() => getHeaders()).toThrow('No request context available');
+    });
+
+    type RequestContextScenario = {
+        name: string,
+        request: PartialRequest,
+        response: PartialResponse,
+    };
+
+    it.each<RequestContextScenario>([
+        ((): RequestContextScenario => {
+            const request = {
+                headers: new Headers(),
+                cookies: {} as NextRequest['cookies'],
+            } satisfies PartialRequest;
+
+            const response: PartialResponse = {
+                headers: new Headers(),
+                cookies: {} as NextResponse['cookies'],
+            } satisfies PartialResponse;
+
+            request.headers.set('foo', 'bar');
+            request.headers.append('bar', 'baz');
+            request.headers.append('bar', 'qux');
+
+            // Ensure it uses the request headers
+            response.headers.set('foo', 'baz');
+
+            return {
+                name: 'NextRequest',
+                request: request,
+                response: response,
+            };
+        })(),
+        ((): RequestContextScenario => {
+            const request = {
+                headers: {
+                    foo: 'bar',
+                    bar: ['baz', 'qux'],
+                },
+                cookies: {} as NextApiRequest['cookies'],
+            } satisfies PartialRequest;
+
+            const response: PartialResponse = {
+                getHeader: jest.fn(() => 'baz'),
+                setHeader: jest.fn(),
+            } satisfies PartialResponse;
+
+            return {
+                name: 'NextApiRequest/PageRouteRequest',
+                request: request,
+                response: response,
+            };
+        })(),
+    ])('should use the $name if specified', scenario => {
+        const {request, response} = scenario;
+
+        mockHeaders.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        const headers = getHeaders({
+            req: request,
+            res: response,
+        });
+
+        expect(headers.get('foo')).toBe('bar');
+        expect(headers.get('bar')).toBe('baz, qux');
+        expect(headers.get('test')).toBeNull();
+    });
+});
+
+describe('getCookies', () => {
+    beforeEach(() => {
+        mockCookies.mockReset();
+    });
+
+    it('should use next/headers if available', () => {
+        const get = jest.fn(() => ({value: 'foo'}));
+        const set = jest.fn();
+
+        mockCookies.mockReturnValue({
+            get: get,
+            set: set,
+        });
+
+        const cookies = getCookies();
+
+        expect(cookies.get('test')).toEqual({value: 'foo'});
+
+        const options: CookieOptions = {
+            domain: 'example.com',
+        };
+
+        cookies.set('test', 'value', options);
+
+        expect(set).toHaveBeenCalledWith('test', 'value', options);
+    });
+
+    it('should require the request context if next/headers is not available', () => {
+        mockCookies.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        expect(() => getCookies()).toThrow('No request context available');
+    });
+
+    type RequestContextScenario = {
+        name: string,
+        request: PartialRequest,
+        response: PartialResponse,
+    };
+
+    it.each<RequestContextScenario>([
+        ((): RequestContextScenario => {
+            const request = {
+                headers: new Headers(),
+                cookies: {
+                    get: (name: string) => {
+                        if (name === 'foo') {
+                            return {value: 'bar'};
+                        }
+
+                        return undefined;
+                    },
+                } as NextRequest['cookies'],
+            } satisfies PartialRequest;
+
+            const response: PartialResponse = {
+                headers: new Headers(),
+                cookies: {
+                    get: () => undefined,
+                } as NextResponse['cookies'],
+            } satisfies PartialResponse;
+
+            return {
+                name: 'NextRequest',
+                request: request,
+                response: response,
+            };
+        })(),
+        ((): RequestContextScenario => {
+            const request = {
+                headers: new Headers(),
+                cookies: {
+                    get: () => undefined,
+                } as NextRequest['cookies'],
+            } satisfies PartialRequest;
+
+            const response: PartialResponse = {
+                headers: new Headers(),
+                cookies: {
+                    get: (name: string) => {
+                        if (name === 'foo') {
+                            return {value: 'bar'};
+                        }
+
+                        return undefined;
+                    },
+                } as NextResponse['cookies'],
+            } satisfies PartialResponse;
+
+            return {
+                name: 'NextResponse',
+                request: request,
+                response: response,
+            };
+        })(),
+        ((): RequestContextScenario => {
+            const request = {
+                headers: {
+                    foo: 'bar',
+                },
+                cookies: {
+                    foo: 'bar',
+                } as NextApiRequest['cookies'],
+            } satisfies PartialRequest;
+
+            const response: PartialResponse = {
+                getHeader: (): string | undefined => undefined,
+                setHeader: jest.fn(),
+            } satisfies PartialResponse;
+
+            return {
+                name: 'NextApiRequest/PageRouteRequest',
+                request: request,
+                response: response,
+            };
+        })(),
+        ((): RequestContextScenario => {
+            const request = {
+                headers: {
+                    foo: 'bar',
+                },
+                cookies: {} as NextApiRequest['cookies'],
+            } satisfies PartialRequest;
+
+            const response: PartialResponse = {
+                getHeader: (name: string): string | undefined => {
+                    if (name === 'Set-Cookie') {
+                        return 'foo=bar';
+                    }
+
+                    return undefined;
+                },
+                setHeader: jest.fn(),
+            } satisfies PartialResponse;
+
+            return {
+                name: 'NextApiResponse/ServerResponse',
+                request: request,
+                response: response,
+            };
+        })(),
+        ((): RequestContextScenario => {
+            const request = {
+                headers: {
+                    foo: 'bar',
+                },
+                cookies: {} as NextApiRequest['cookies'],
+            } satisfies PartialRequest;
+
+            const response: PartialResponse = {
+                getHeader: (name: string): string[]|undefined => {
+                    if (name === 'Set-Cookie') {
+                        return ['foo=bar', 'bar=baz'];
+                    }
+
+                    return undefined;
+                },
+                setHeader: jest.fn(),
+            } satisfies PartialResponse;
+
+            return {
+                name: 'NextApiResponse/ServerResponse with multiple cookies',
+                request: request,
+                response: response,
+            };
+        })(),
+    ])('should use the $name if specified', scenario => {
+        const {request, response} = scenario;
+
+        mockCookies.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        const cookies = getCookies({
+            req: request,
+            res: response,
+        });
+
+        expect(cookies.get('foo')).toEqual({value: 'bar'});
+        expect(cookies.get('test')).toBeUndefined();
+    });
+
+    it('should set a cookie to NextResponse', () => {
+        mockCookies.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        const request = {
+            headers: new Headers(),
+            cookies: {} as NextRequest['cookies'],
+        } satisfies PartialRequest;
+
+        const response: PartialResponse = {
+            headers: new Headers(),
+            cookies: {
+                set: jest.fn(),
+            } as Partial<NextResponse['cookies']> as NextResponse['cookies'],
+        } satisfies PartialResponse;
+
+        const cookies = getCookies({
+            req: request,
+            res: response,
+        });
+
+        const options: CookieOptions = {
+            domain: 'example.com',
+        };
+
+        cookies.set('test', 'value', options);
+
+        expect(response.cookies.set).toHaveBeenCalledWith('test', 'value', options);
+    });
+
+    it('should set a cookie to NextApiResponse/ServerResponse', () => {
+        mockCookies.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        const request = {
+            headers: new Headers(),
+            cookies: {} as NextRequest['cookies'],
+        } satisfies PartialRequest;
+
+        const response: PartialResponse = {
+            getHeader: jest.fn(),
+            setHeader: jest.fn(),
+        } satisfies PartialResponse;
+
+        const cookies = getCookies({
+            req: request,
+            res: response,
+        });
+
+        const options: CookieOptions = {
+            domain: 'example.com',
+        };
+
+        cookies.set('test', 'value', options);
+
+        expect(response.setHeader).toHaveBeenCalledWith('Set-Cookie', ['test=value; Domain=example.com']);
+    });
+
+    it('should preserve existing cookies when setting a new cookie', () => {
+        mockCookies.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        const request = {
+            headers: new Headers(),
+            cookies: {} as NextRequest['cookies'],
+        } satisfies PartialRequest;
+
+        const response: PartialResponse = {
+            getHeader: (name: string): string[]|undefined => {
+                if (name === 'Set-Cookie') {
+                    return [
+                        'foo=bar',
+                        'bar=baz',
+                        'test=old; secure',
+                    ];
+                }
+
+                return undefined;
+            },
+            setHeader: jest.fn(),
+        } satisfies PartialResponse;
+
+        const cookies = getCookies({
+            req: request,
+            res: response,
+        });
+
+        const now = Date.now();
+
+        const options: CookieOptions = {
+            domain: 'example.com',
+            expires: now,
+        };
+
+        cookies.set('test', 'value', options);
+
+        expect(response.setHeader).toHaveBeenCalledWith(
+            'Set-Cookie',
+            [
+                'foo=bar',
+                'bar=baz',
+                `test=value; Domain=example.com; Expires=${new Date(now).toUTCString()}`,
+            ],
+        );
+    });
+});
+
+describe('isAppRouter', () => {
+    beforeEach(() => {
+        mockHeaders.mockReset();
+    });
+
+    it('should return true if next/headers is available', () => {
+        expect(isAppRouter()).toBe(true);
+    });
+
+    it('should return false if next/headers is not available', () => {
+        mockHeaders.mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        expect(isAppRouter()).toBe(false);
+    });
+});

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,177 @@
+import type {ServerResponse} from 'http';
+import type {NextRequest, NextResponse} from 'next/server';
+import type {GetServerSidePropsContext, NextApiRequest, NextApiResponse} from 'next';
+import type {cookies, headers} from 'next/headers';
+import cookie from 'cookie';
+
+export type HeaderReader = Pick<ReturnType<typeof headers>, 'get'>;
+
+export type CookieReader = {
+    get: (name: string) => {value: string}|undefined,
+};
+
+export type CookieOptions = NonNullable<Parameters<ReturnType<typeof cookies>['set']>[2]>;
+
+export type CookieAccessor = CookieReader & {
+    set: (name: string, value: string, options?: CookieOptions) => void,
+};
+
+type PageRequest = Pick<GetServerSidePropsContext['req'], 'headers' | 'cookies'>;
+
+export type PartialRequest = Pick<NextRequest, 'headers' | 'cookies'>
+    | Pick<NextApiRequest, 'headers' | 'cookies'>
+    | PageRequest;
+
+export type PartialResponse = Pick<NextResponse, 'headers' | 'cookies'>
+    | Pick<NextApiResponse, 'getHeader' | 'setHeader'>
+    | Pick<ServerResponse, 'getHeader' | 'setHeader'>;
+
+export type NextRequestContext = {
+    req: PartialRequest,
+    res: PartialResponse,
+};
+
+export function getHeaders(context?: NextRequestContext): HeaderReader {
+    try {
+        const {headers} = importNextHeaders();
+
+        return headers();
+    } catch {
+        if (context === undefined) {
+            throw new Error('No request context available');
+        }
+    }
+
+    return {
+        get: (name: string): string|null => {
+            const requestHeaders = context.req.headers;
+
+            if (isNextRequestHeaders(requestHeaders)) {
+                return requestHeaders.get(name);
+            }
+
+            const value = requestHeaders[name];
+
+            if (typeof value === 'string') {
+                return value;
+            }
+
+            if (Array.isArray(value)) {
+                return value.join(', ');
+            }
+
+            return null;
+        },
+    };
+}
+
+export function getCookies(context?: NextRequestContext): CookieAccessor {
+    try {
+        const {cookies} = importNextHeaders();
+
+        return cookies();
+    } catch {
+        if (context === undefined) {
+            throw new Error('No request context available');
+        }
+    }
+
+    return {
+        get: (name: string): {value: string}|undefined => {
+            const {res} = context;
+
+            // First check if the cookie is set in the response
+            // as it is the most recent value
+            if ('cookies' in res) {
+                const responseValue = res.cookies.get(name);
+
+                if (responseValue !== undefined) {
+                    return {value: responseValue.value};
+                }
+            } else {
+                const responseValue = res.getHeader('Set-Cookie') ?? [];
+                const lines = Array.isArray(responseValue) ? responseValue : [`${responseValue}`];
+
+                for (const line of lines) {
+                    const parsedHeader = cookie.parse(line.split(';')[0]);
+
+                    if (parsedHeader[name] !== undefined) {
+                        return {value: parsedHeader[name]};
+                    }
+                }
+            }
+
+            // Next check if the cookie is set in the request
+            const requestCookies = context.req.cookies;
+
+            if (isNextRequestCookies(requestCookies)) {
+                return requestCookies.get(name);
+            }
+
+            const value = requestCookies[name];
+
+            if (value !== undefined) {
+                return {value: value};
+            }
+
+            return undefined;
+        },
+        set: (name, value, options): void => {
+            const {res} = context;
+
+            if ('cookies' in res) {
+                res.cookies.set(name, value, options);
+
+                return;
+            }
+
+            const responseValue = res.getHeader('Set-Cookie') ?? [];
+            const previousValue = Array.isArray(responseValue) ? responseValue : [`${responseValue}`];
+            const newValue = previousValue.flatMap(line => {
+                const parsedHeader = cookie.parse(line.split(';')[0]);
+
+                if (parsedHeader[name] !== undefined) {
+                    return [];
+                }
+
+                return [line];
+            });
+
+            const expires = options?.expires;
+
+            newValue.push(cookie.serialize(name, value, {
+                ...options,
+                expires: typeof expires === 'number'
+                    ? new Date(expires)
+                    : expires,
+            }));
+
+            res.setHeader('Set-Cookie', newValue);
+        },
+    };
+}
+
+function isNextRequestHeaders(headers: PartialRequest['headers']): headers is NextRequest['headers'] {
+    return headers.append !== undefined;
+}
+
+function isNextRequestCookies(cookies: PartialRequest['cookies']): cookies is NextRequest['cookies'] {
+    return cookies.get !== undefined || cookies.set !== undefined;
+}
+
+export function isAppRouter(): boolean {
+    try {
+        const {headers} = importNextHeaders();
+
+        headers();
+    } catch {
+        return false;
+    }
+
+    return true;
+}
+
+function importNextHeaders(): typeof import('next/headers') {
+    // eslint-disable-next-line global-require -- Required for dynamic import
+    return require('next/headers');
+}

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -26,12 +26,12 @@ export type PartialResponse = Pick<NextResponse, 'headers' | 'cookies'>
     | Pick<NextApiResponse, 'getHeader' | 'setHeader'>
     | Pick<ServerResponse, 'getHeader' | 'setHeader'>;
 
-export type NextRequestContext = {
+export type RouteContext = {
     req: PartialRequest,
     res: PartialResponse,
 };
 
-export function getHeaders(context?: NextRequestContext): HeaderReader {
+export function getHeaders(context?: RouteContext): HeaderReader {
     try {
         const {headers} = importNextHeaders();
 
@@ -65,7 +65,7 @@ export function getHeaders(context?: NextRequestContext): HeaderReader {
     };
 }
 
-export function getCookies(context?: NextRequestContext): CookieAccessor {
+export function getCookies(context?: RouteContext): CookieAccessor {
     try {
         const {cookies} = importNextHeaders();
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -3,6 +3,7 @@ import parseSetCookies, {Cookie} from 'set-cookie-parser';
 import {Token} from '@croct/sdk/token';
 import {v4 as uuid} from 'uuid';
 import {ApiKey} from '@croct/sdk/apiKey';
+import * as process from 'node:process';
 import {Header, QueryParameter} from '@/config/http';
 import {config, withCroct} from '@/middleware';
 import {getAppId} from '@/config/appId';
@@ -135,11 +136,13 @@ describe('middleware', () => {
         delete process.env.CROCT_DISABLE_USER_TOKEN_AUTHENTICATION;
 
         process.env.NEXT_PUBLIC_CROCT_APP_ID = '00000000-0000-0000-0000-000000000000';
-        process.env.NODE_ENV = 'production';
+
+        Object.assign(process.env, {NODE_ENV: 'production'});
     });
 
     afterEach(() => {
-        process.env = {...ENV_VARS};
+        Object.assign(process.env, ENV_VARS);
+
         jest.useRealTimers();
     });
 

--- a/src/server/anonymize.test.ts
+++ b/src/server/anonymize.test.ts
@@ -91,7 +91,7 @@ describe('anonymize', () => {
         });
 
         await expect(anonymize).rejects.toThrow(
-            'The anonymize() function requires a server-side context outside app routes. '
+            'anonymize() requires specifying the `route` parameter outside app routes. '
             + 'For help, see: https://croct.help/sdk/nextjs/anonymize-route-context',
         );
     });

--- a/src/server/anonymize.test.ts
+++ b/src/server/anonymize.test.ts
@@ -3,7 +3,7 @@ import {Token} from '@croct/sdk/token';
 import type {NextRequest, NextResponse} from 'next/server';
 import {issueToken} from '@/config/security';
 import {anonymize} from '@/server/anonymize';
-import {getCookies, NextRequestContext} from '@/headers';
+import {getCookies, RouteContext} from '@/headers';
 
 jest.mock(
     '@/config/security',
@@ -67,7 +67,7 @@ describe('anonymize', () => {
 
         jest.mocked(issueToken).mockResolvedValue(token);
 
-        const context: NextRequestContext = {
+        const context: RouteContext = {
             req: {} as NextRequest,
             res: {} as NextResponse,
         };
@@ -85,14 +85,14 @@ describe('anonymize', () => {
         });
     });
 
-    it('should report an error if the request context is missing', async () => {
+    it('should report an error if the route context is missing', async () => {
         jest.mocked(cookies).mockImplementation(() => {
             throw new Error('next/headers requires app router');
         });
 
         await expect(anonymize).rejects.toThrow(
             'The anonymize() function requires a server-side context outside app routes. '
-            + 'For help, see: https://croct.help/sdk/nextjs/anonymize-missing-context',
+            + 'For help, see: https://croct.help/sdk/nextjs/anonymize-route-context',
         );
     });
 });

--- a/src/server/anonymize.test.ts
+++ b/src/server/anonymize.test.ts
@@ -1,7 +1,9 @@
 import {cookies} from 'next/headers';
 import {Token} from '@croct/sdk/token';
+import type {NextRequest, NextResponse} from 'next/server';
 import {issueToken} from '@/config/security';
 import {anonymize} from '@/server/anonymize';
+import {getCookies, NextRequestContext} from '@/headers';
 
 jest.mock(
     '@/config/security',
@@ -32,41 +34,65 @@ jest.mock(
 
 jest.mock(
     'next/headers',
-    () => {
-        const methods = {
-            set: jest.fn(),
-        };
-
-        return {
-            __esModule: true,
-            ...jest.requireActual('next/headers'),
-            cookies: jest.fn(() => methods),
-        };
-    },
+    () => ({
+        __esModule: true,
+        ...jest.requireActual('next/headers'),
+        cookies: jest.fn(),
+    }),
 );
+
+jest.mock('@/headers', () => {
+    const original = jest.requireActual('@/headers');
+
+    return {
+        __esModule: true,
+        ...original,
+        getCookies: jest.fn(original.getCookies),
+    };
+});
 
 describe('anonymize', () => {
     afterEach(() => {
-        jest.mocked(cookies().set).mockClear();
+        jest.mocked(cookies).mockReset();
     });
 
     it('should set a token in the cookie', async () => {
         const token = Token.issue('00000000-0000-0000-0000-000000000001');
 
+        const set = jest.fn();
+
+        jest.mocked(cookies).mockReturnValue(
+            {set: set} as Partial<ReturnType<typeof cookies>> as ReturnType<typeof cookies>,
+        );
+
         jest.mocked(issueToken).mockResolvedValue(token);
 
-        await expect(anonymize()).resolves.toBeUndefined();
+        const context: NextRequestContext = {
+            req: {} as NextRequest,
+            res: {} as NextResponse,
+        };
 
-        const jar = cookies();
+        await expect(anonymize(context)).resolves.toBeUndefined();
 
-        expect(jar.set).toHaveBeenCalledWith({
-            name: 'croct',
+        expect(getCookies).toHaveBeenCalledWith(context);
+
+        expect(set).toHaveBeenCalledWith('croct', token.toString(), {
             maxAge: 86400,
             path: '/',
             domain: undefined,
             secure: false,
             sameSite: 'lax',
-            value: token.toString(),
         });
+    });
+
+    it('should report an error if the request context is missing', async () => {
+        jest.mocked(cookies).mockImplementation(() => {
+            throw new Error('next/headers requires app router');
+        });
+
+        await expect(anonymize).rejects.toThrow(
+            'The anonymize() function requires a server-side context outside app routes. '
+            + 'For help, see: https://croct.help/sdk/nextjs/anonymize-missing-context',
+        );
     });
 });

--- a/src/server/anonymize.ts
+++ b/src/server/anonymize.ts
@@ -1,19 +1,27 @@
-import {cookies} from 'next/headers';
 import {getUserTokenCookieOptions} from '@/config/cookie';
 import {issueToken} from '@/config/security';
+import {CookieAccessor, getCookies, NextRequestContext} from '@/headers';
 
-export async function anonymize(): Promise<void> {
+export async function anonymize(context?: NextRequestContext): Promise<void> {
+    let cookies: CookieAccessor;
+
+    try {
+        cookies = getCookies(context);
+    } catch {
+        throw new Error(
+            'The anonymize() function requires a server-side context outside app routes. '
+            + 'For help, see: https://croct.help/sdk/nextjs/anonymize-missing-context',
+        );
+    }
+
     const token = await issueToken();
-    const jar = cookies();
     const cookieOptions = getUserTokenCookieOptions();
 
-    jar.set({
-        name: cookieOptions.name,
+    cookies.set(cookieOptions.name, token.toString(), {
         maxAge: cookieOptions.maxAge,
         path: cookieOptions.path,
         domain: cookieOptions.domain,
         secure: cookieOptions.secure,
         sameSite: cookieOptions.sameSite,
-        value: token.toString(),
     });
 }

--- a/src/server/anonymize.ts
+++ b/src/server/anonymize.ts
@@ -9,7 +9,7 @@ export async function anonymize(context?: RouteContext): Promise<void> {
         cookies = getCookies(context);
     } catch {
         throw new Error(
-            'The anonymize() function requires a server-side context outside app routes. '
+            'anonymize() requires specifying the `route` parameter outside app routes. '
             + 'For help, see: https://croct.help/sdk/nextjs/anonymize-route-context',
         );
     }

--- a/src/server/anonymize.ts
+++ b/src/server/anonymize.ts
@@ -1,8 +1,8 @@
 import {getUserTokenCookieOptions} from '@/config/cookie';
 import {issueToken} from '@/config/security';
-import {CookieAccessor, getCookies, NextRequestContext} from '@/headers';
+import {CookieAccessor, getCookies, RouteContext} from '@/headers';
 
-export async function anonymize(context?: NextRequestContext): Promise<void> {
+export async function anonymize(context?: RouteContext): Promise<void> {
     let cookies: CookieAccessor;
 
     try {
@@ -10,7 +10,7 @@ export async function anonymize(context?: NextRequestContext): Promise<void> {
     } catch {
         throw new Error(
             'The anonymize() function requires a server-side context outside app routes. '
-            + 'For help, see: https://croct.help/sdk/nextjs/anonymize-missing-context',
+            + 'For help, see: https://croct.help/sdk/nextjs/anonymize-route-context',
         );
     }
 

--- a/src/server/evaluate.test.ts
+++ b/src/server/evaluate.test.ts
@@ -187,7 +187,7 @@ describe('evaluation', () => {
             });
 
             await expect(evaluate('true')).rejects.toThrow(
-                'The evaluate() function requires a server-side context outside app routes. '
+                'evaluate() requires specifying the `route` option outside app routes. '
                 + 'For help, see: https://croct.help/sdk/nextjs/evaluate-route-context',
             );
         });

--- a/src/server/evaluate.test.ts
+++ b/src/server/evaluate.test.ts
@@ -11,13 +11,6 @@ import {getApiKey} from '@/config/security';
 import {getCookies, getHeaders, NextRequestContext} from '@/headers';
 
 jest.mock(
-    'server-only',
-    () => ({
-        __esModule: true,
-    }),
-);
-
-jest.mock(
     'next/headers',
     () => ({
         __esModule: true,

--- a/src/server/evaluate.test.ts
+++ b/src/server/evaluate.test.ts
@@ -187,7 +187,7 @@ describe('evaluation', () => {
             jest.mocked(getRequestContext).mockReturnValue(request);
             jest.mocked(executeQuery).mockResolvedValue(true);
 
-            await expect(evaluate('true', {requestContext: context})).resolves.toBe(true);
+            await expect(evaluate('true', {route: context})).resolves.toBe(true);
 
             expect(getHeaders).toHaveBeenCalledWith(context);
             expect(getCookies).toHaveBeenCalledWith(context);

--- a/src/server/evaluate.ts
+++ b/src/server/evaluate.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import {evaluate as executeQuery, EvaluationOptions as BaseOptions} from '@croct/plug-react/api';
 import type {JsonValue} from '@croct/plug-react';
 import {FilteredLogger} from '@croct/sdk/logging/filteredLogger';

--- a/src/server/evaluate.ts
+++ b/src/server/evaluate.ts
@@ -21,7 +21,7 @@ export function evaluate<T extends JsonValue>(query: string, options: Evaluation
         if (route === undefined) {
             return Promise.reject(
                 new Error(
-                    'The evaluate() function requires a server-side context outside app routes. '
+                    'evaluate() requires specifying the `route` option outside app routes. '
                     + 'For help, see: https://croct.help/sdk/nextjs/evaluate-route-context',
                 ),
             );

--- a/src/server/evaluate.ts
+++ b/src/server/evaluate.ts
@@ -8,12 +8,12 @@ import {getDefaultFetchTimeout} from '@/config/timeout';
 import {getCookies, getHeaders, isAppRouter, NextRequestContext} from '@/headers';
 
 export type EvaluationOptions<T extends JsonValue = JsonValue> = Omit<BaseOptions<T>, 'apiKey' | 'appId'> & {
-    requestContext?: NextRequestContext,
+    route?: NextRequestContext,
 };
 
 export function evaluate<T extends JsonValue>(query: string, options: EvaluationOptions<T> = {}): Promise<T> {
-    const {requestContext, ...rest} = options;
-    const context = getRequestContext(getHeaders(requestContext), getCookies(requestContext));
+    const {route, ...rest} = options;
+    const context = getRequestContext(getHeaders(route), getCookies(route));
 
     return executeQuery<T>(query, {
         apiKey: getApiKey(),

--- a/src/server/evaluate.ts
+++ b/src/server/evaluate.ts
@@ -2,40 +2,43 @@ import 'server-only';
 
 import {evaluate as executeQuery, EvaluationOptions as BaseOptions} from '@croct/plug-react/api';
 import type {JsonValue} from '@croct/plug-react';
-import {cookies, headers} from 'next/headers';
 import {FilteredLogger} from '@croct/sdk/logging/filteredLogger';
 import {ConsoleLogger} from '@croct/sdk/logging/consoleLogger';
 import {getApiKey} from '@/config/security';
 import {getRequestContext} from '@/config/context';
 import {getDefaultFetchTimeout} from '@/config/timeout';
+import {getCookies, getHeaders, isAppRouter, NextRequestContext} from '@/headers';
 
-export type EvaluationOptions<T extends JsonValue = JsonValue> = Omit<BaseOptions<T>, 'apiKey' | 'appId'>;
+export type EvaluationOptions<T extends JsonValue = JsonValue> = Omit<BaseOptions<T>, 'apiKey' | 'appId'> & {
+    requestContext?: NextRequestContext,
+};
 
 export function evaluate<T extends JsonValue>(query: string, options: EvaluationOptions<T> = {}): Promise<T> {
-    const request = getRequestContext(headers(), cookies());
+    const {requestContext, ...rest} = options;
+    const context = getRequestContext(getHeaders(requestContext), getCookies(requestContext));
 
     return executeQuery<T>(query, {
         apiKey: getApiKey(),
-        clientIp: request.clientIp ?? '127.0.0.1',
-        ...(request.previewToken !== undefined && {previewToken: request.previewToken}),
-        ...(request.userToken !== undefined && {userToken: request.userToken}),
-        ...(request.clientId !== undefined && {clientId: request.clientId}),
-        ...(request.clientAgent !== undefined && {clientAgent: request.clientAgent}),
+        clientIp: context.clientIp ?? '127.0.0.1',
+        ...(context.previewToken !== undefined && {previewToken: context.previewToken}),
+        ...(context.userToken !== undefined && {userToken: context.userToken}),
+        ...(context.clientId !== undefined && {clientId: context.clientId}),
+        ...(context.clientAgent !== undefined && {clientAgent: context.clientAgent}),
         timeout: getDefaultFetchTimeout(),
         extra: {
             cache: 'no-store',
         },
-        ...options,
-        logger: options.logger ?? FilteredLogger.include(new ConsoleLogger(), ['warn', 'error']),
-        ...(request.uri !== undefined
+        ...rest,
+        logger: rest.logger ?? FilteredLogger.include(new ConsoleLogger(), ['warn', 'error']),
+        ...(context.uri !== undefined
             ? {
                 context: {
                     page: {
-                        url: request.uri,
-                        ...(request.referrer !== null ? {referrer: request.referrer} : {}),
-                        ...options.context?.page,
+                        url: context.uri,
+                        ...(context.referrer !== null ? {referrer: context.referrer} : {}),
+                        ...rest.context?.page,
                     },
-                    ...options.context,
+                    ...rest.context,
                 },
             }
             : {}
@@ -44,6 +47,15 @@ export function evaluate<T extends JsonValue>(query: string, options: Evaluation
 }
 
 export function cql<T extends JsonValue>(fragments: TemplateStringsArray, ...args: JsonValue[]): Promise<T> {
+    if (!isAppRouter()) {
+        return Promise.reject(
+            new Error(
+                'The cql tag function can only be used with App Router. '
+                + 'For help, see https://croct.help/sdk/nextjs/cql-missing-context',
+            ),
+        );
+    }
+
     const {query, variables} = buildQuery(fragments, args);
 
     return evaluate<T>(

--- a/src/server/fetchContent.test.ts
+++ b/src/server/fetchContent.test.ts
@@ -225,7 +225,7 @@ describe('fetchContent', () => {
         });
 
         await fetchContent('slot-id', {
-            requestContext: context,
+            route: context,
         });
 
         expect(getHeaders).toHaveBeenCalledWith(context);

--- a/src/server/fetchContent.test.ts
+++ b/src/server/fetchContent.test.ts
@@ -11,13 +11,6 @@ import {getApiKey} from '@/config/security';
 import {getCookies, getHeaders, NextRequestContext} from '@/headers';
 
 jest.mock(
-    'server-only',
-    () => ({
-        __esModule: true,
-    }),
-);
-
-jest.mock(
     'next/headers',
     () => ({
         __esModule: true,

--- a/src/server/fetchContent.test.ts
+++ b/src/server/fetchContent.test.ts
@@ -226,7 +226,7 @@ describe('fetchContent', () => {
         });
 
         await expect(fetchContent('slot-id')).rejects.toThrow(
-            'The fetchContent() function requires a server-side context outside app routes. '
+            'fetchContent() requires specifying the `route` option outside app routes. '
             + 'For help, see: https://croct.help/sdk/nextjs/fetch-content-route-context',
         );
     });

--- a/src/server/fetchContent.ts
+++ b/src/server/fetchContent.ts
@@ -8,15 +8,15 @@ import {getDefaultFetchTimeout} from '@/config/timeout';
 import {getCookies, getHeaders, NextRequestContext} from '@/headers';
 
 export type FetchOptions<T extends JsonObject = JsonObject> = Omit<DynamicContentOptions<T>, 'apiKey' | 'appId'> & {
-    requestContext?: NextRequestContext,
+    route?: NextRequestContext,
 };
 
 export function fetchContent<I extends VersionedSlotId, C extends JsonObject>(
     slotId: I,
     options: FetchOptions<SlotContent<I, C>> = {},
 ): Promise<SlotContent<I, C>> {
-    const {requestContext, ...rest} = options;
-    const context = getRequestContext(getHeaders(requestContext), getCookies(requestContext));
+    const {route, ...rest} = options;
+    const context = getRequestContext(getHeaders(route), getCookies(route));
     const promise = loadContent<I, C>(slotId, {
         apiKey: getApiKey(),
         clientIp: context.clientIp ?? '127.0.0.1',

--- a/src/server/fetchContent.ts
+++ b/src/server/fetchContent.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import {DynamicContentOptions, fetchContent as loadContent} from '@croct/plug-react/api';
 import type {SlotContent, VersionedSlotId, JsonObject} from '@croct/plug-react';
 import {FilteredLogger} from '@croct/sdk/logging/filteredLogger';

--- a/src/server/fetchContent.ts
+++ b/src/server/fetchContent.ts
@@ -25,7 +25,7 @@ export function fetchContent<I extends VersionedSlotId, C extends JsonObject>(
         if (route === undefined) {
             return Promise.reject(
                 new Error(
-                    'The fetchContent() function requires a server-side context outside app routes. '
+                    'fetchContent() requires specifying the `route` option outside app routes. '
                     + 'For help, see: https://croct.help/sdk/nextjs/fetch-content-route-context',
                 ),
             );

--- a/src/server/identify.test.ts
+++ b/src/server/identify.test.ts
@@ -3,7 +3,7 @@ import {Token} from '@croct/sdk/token';
 import type {NextRequest, NextResponse} from 'next/server';
 import {issueToken} from '@/config/security';
 import {identify} from '@/server/identify';
-import {getCookies, NextRequestContext} from '@/headers';
+import {getCookies, RouteContext} from '@/headers';
 
 jest.mock(
     '@/config/security',
@@ -68,7 +68,7 @@ describe('identify', () => {
 
         jest.mocked(issueToken).mockResolvedValue(token);
 
-        const context: NextRequestContext = {
+        const context: RouteContext = {
             req: {} as NextRequest,
             res: {} as NextResponse,
         };
@@ -86,14 +86,14 @@ describe('identify', () => {
         });
     });
 
-    it('should report an error if the request context is missing', async () => {
+    it('should report an error if the route context is missing', async () => {
         jest.mocked(cookies).mockImplementation(() => {
             throw new Error('next/headers requires app router');
         });
 
         await expect(() => identify('foo')).rejects.toThrow(
             'The identify() function requires a server-side context outside app routes. '
-            + 'For help, see: https://croct.help/sdk/nextjs/identify-missing-context',
+            + 'For help, see: https://croct.help/sdk/nextjs/identify-route-context',
         );
     });
 });

--- a/src/server/identify.test.ts
+++ b/src/server/identify.test.ts
@@ -92,7 +92,7 @@ describe('identify', () => {
         });
 
         await expect(() => identify('foo')).rejects.toThrow(
-            'The identify() function requires a server-side context outside app routes. '
+            'identify() requires specifying the `route` parameter outside app routes. '
             + 'For help, see: https://croct.help/sdk/nextjs/identify-route-context',
         );
     });

--- a/src/server/identify.ts
+++ b/src/server/identify.ts
@@ -1,19 +1,27 @@
-import {cookies} from 'next/headers';
 import {issueToken} from '@/config/security';
 import {getUserTokenCookieOptions} from '@/config/cookie';
+import {getCookies, NextRequestContext, CookieAccessor} from '@/headers';
 
-export async function identify(userId: string): Promise<void> {
+export async function identify(userId: string, context?: NextRequestContext): Promise<void> {
+    let cookies: CookieAccessor;
+
+    try {
+        cookies = getCookies(context);
+    } catch {
+        throw new Error(
+            'The identify() function requires a server-side context outside app routes. '
+            + 'For help, see: https://croct.help/sdk/nextjs/identify-missing-context',
+        );
+    }
+
     const token = await issueToken(userId);
-    const jar = cookies();
     const cookieOptions = getUserTokenCookieOptions();
 
-    jar.set({
-        name: cookieOptions.name,
+    cookies.set(cookieOptions.name, token.toString(), {
         maxAge: cookieOptions.maxAge,
         path: cookieOptions.path,
         domain: cookieOptions.domain,
         secure: cookieOptions.secure,
         sameSite: cookieOptions.sameSite,
-        value: token.toString(),
     });
 }

--- a/src/server/identify.ts
+++ b/src/server/identify.ts
@@ -2,14 +2,14 @@ import {issueToken} from '@/config/security';
 import {getUserTokenCookieOptions} from '@/config/cookie';
 import {getCookies, RouteContext, CookieAccessor} from '@/headers';
 
-export async function identify(userId: string, context?: RouteContext): Promise<void> {
+export async function identify(userId: string, route?: RouteContext): Promise<void> {
     let cookies: CookieAccessor;
 
     try {
-        cookies = getCookies(context);
+        cookies = getCookies(route);
     } catch {
         throw new Error(
-            'The identify() function requires a server-side context outside app routes. '
+            'identify() requires specifying the `route` parameter outside app routes. '
             + 'For help, see: https://croct.help/sdk/nextjs/identify-route-context',
         );
     }

--- a/src/server/identify.ts
+++ b/src/server/identify.ts
@@ -1,8 +1,8 @@
 import {issueToken} from '@/config/security';
 import {getUserTokenCookieOptions} from '@/config/cookie';
-import {getCookies, NextRequestContext, CookieAccessor} from '@/headers';
+import {getCookies, RouteContext, CookieAccessor} from '@/headers';
 
-export async function identify(userId: string, context?: NextRequestContext): Promise<void> {
+export async function identify(userId: string, context?: RouteContext): Promise<void> {
     let cookies: CookieAccessor;
 
     try {
@@ -10,7 +10,7 @@ export async function identify(userId: string, context?: NextRequestContext): Pr
     } catch {
         throw new Error(
             'The identify() function requires a server-side context outside app routes. '
-            + 'For help, see: https://croct.help/sdk/nextjs/identify-missing-context',
+            + 'For help, see: https://croct.help/sdk/nextjs/identify-route-context',
         );
     }
 


### PR DESCRIPTION
## Summary
This pull request adds support for using the `evaluate`, `fetchContent`, `identify`, and `anonymize` with the Page router or from APIs.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings