### PR TITLE
Allow specifying base URL per environment

### DIFF
--- a/src/CroctProvider.test.tsx
+++ b/src/CroctProvider.test.tsx
@@ -27,6 +27,7 @@ describe('<CroctProvider />', () => {
 
         delete process.env.NEXT_PUBLIC_CROCT_APP_ID;
         delete process.env.NEXT_PUBLIC_CROCT_DEBUG;
+        delete process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL;
     });
 
     afterEach(() => {
@@ -65,10 +66,12 @@ describe('<CroctProvider />', () => {
     it('should allow overriding the environment configuration', () => {
         process.env.NEXT_PUBLIC_CROCT_APP_ID = '00000000-0000-0000-0000-000000000000';
         process.env.NEXT_PUBLIC_CROCT_DEBUG = 'true';
+        process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL = 'https://example.com';
 
         const config = {
             appId: '11111111-1111-1111-1111-111111111111',
             debug: false,
+            baseEndpointUrl: 'https://override.com',
             cookie: {
                 clientId: {
                     name: 'custom-client-id',
@@ -92,6 +95,7 @@ describe('<CroctProvider />', () => {
                 appId: config.appId,
                 debug: config.debug,
                 cookie: config.cookie,
+                baseEndpointUrl: config.baseEndpointUrl,
             },
             expect.anything(),
         );
@@ -119,6 +123,20 @@ describe('<CroctProvider />', () => {
         expect(UnderlyingProvider).toHaveBeenCalledWith<[ResolvedProviderProps, any]>(
             expect.objectContaining({
                 debug: true,
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('should detect the base endpoint URL from the environment', () => {
+        process.env.NEXT_PUBLIC_CROCT_APP_ID = '00000000-0000-0000-0000-000000000000';
+        process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL = 'https://example.com';
+
+        render(<CroctProvider />);
+
+        expect(UnderlyingProvider).toHaveBeenCalledWith<[ResolvedProviderProps, any]>(
+            expect.objectContaining({
+                baseEndpointUrl: process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL,
             }),
             expect.anything(),
         );

--- a/src/CroctProvider.tsx
+++ b/src/CroctProvider.tsx
@@ -15,11 +15,14 @@ export type CroctProviderProps = Omit<ReactCroctProviderProps, OmittedProps>
 
 export const CroctProvider: FunctionComponent<CroctProviderProps> = props => {
     const {appId = getAppId(), ...rest} = props;
+    const debugMode = process.env.NEXT_PUBLIC_CROCT_DEBUG === 'true';
+    const endpointUrl = normalizeEnvVar(process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL);
 
     return (
         <ReactCroctProvider
-            debug={process.env.NEXT_PUBLIC_CROCT_DEBUG === 'true'}
+            debug={debugMode}
             appId={appId}
+            {...(endpointUrl !== undefined ? {baseEndpointUrl: endpointUrl} : {})}
             cookie={{
                 clientId: getClientIdCookieOptions(),
                 userToken: getUserTokenCookieOptions(),
@@ -29,3 +32,7 @@ export const CroctProvider: FunctionComponent<CroctProviderProps> = props => {
         />
     );
 };
+
+function normalizeEnvVar(value: string | undefined): string|undefined {
+    return value === undefined || value === '' ? undefined : value;
+}


### PR DESCRIPTION
## Summary
This PR adds a new env var to allow specifying the base URL from the environment variables.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings