### PR TITLE
Use env vars config

### DIFF
--- a/src/CroctProvider.test.tsx
+++ b/src/CroctProvider.test.tsx
@@ -52,7 +52,6 @@ describe('<CroctProvider />', () => {
         expect(UnderlyingProvider).toHaveBeenCalledWith<[ResolvedProviderProps, any]>(
             {
                 appId: '00000000-0000-0000-0000-000000000000',
-                debug: false,
                 cookie: {
                     clientId: getClientIdCookieOptions(),
                     userToken: getUserTokenCookieOptions(),

--- a/src/CroctProvider.tsx
+++ b/src/CroctProvider.tsx
@@ -7,6 +7,7 @@ import {
 import {FunctionComponent} from 'react';
 import {getClientIdCookieOptions, getPreviewCookieOptions, getUserTokenCookieOptions} from '@/config/cookie';
 import {getAppId} from '@/config/appId';
+import {getEnvEntry, getEnvEntryFlag} from '@/config/env';
 
 type OmittedProps = 'appId' | 'disableCidMirroring' | 'cidAssignerEndpointUrl';
 
@@ -15,14 +16,12 @@ export type CroctProviderProps = Omit<ReactCroctProviderProps, OmittedProps>
 
 export const CroctProvider: FunctionComponent<CroctProviderProps> = props => {
     const {appId = getAppId(), ...rest} = props;
-    const debugMode = process.env.NEXT_PUBLIC_CROCT_DEBUG === 'true';
-    const endpointUrl = normalizeEnvVar(process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL);
 
     return (
         <ReactCroctProvider
-            debug={debugMode}
             appId={appId}
-            {...(endpointUrl !== undefined ? {baseEndpointUrl: endpointUrl} : {})}
+            {...getEnvEntryFlag('debug', process.env.NEXT_PUBLIC_CROCT_DEBUG)}
+            {...getEnvEntry('baseEndpointUrl', process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL)}
             cookie={{
                 clientId: getClientIdCookieOptions(),
                 userToken: getUserTokenCookieOptions(),
@@ -32,7 +31,3 @@ export const CroctProvider: FunctionComponent<CroctProviderProps> = props => {
         />
     );
 };
-
-function normalizeEnvVar(value: string | undefined): string|undefined {
-    return value === undefined || value === '' ? undefined : value;
-}

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,0 +1,64 @@
+import {getEnvEntry, getEnvEntryFlag, getEnvFlag, getEnvValue} from '@/config/env';
+
+describe('getEnvEntry', () => {
+    it('should return undefined if the value is undefined', () => {
+        expect(getEnvEntry('key', undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if the value is an empty string', () => {
+        expect(getEnvEntry('key', '')).toBeUndefined();
+    });
+
+    it('should return the normalized value', () => {
+        expect(getEnvEntry('key', 'value', value => value.toUpperCase())).toEqual({key: 'VALUE'});
+    });
+});
+
+describe('getEnvEntryFlag', () => {
+    it('should return undefined if the value is undefined', () => {
+        expect(getEnvEntryFlag('key', undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if the value is an empty string', () => {
+        expect(getEnvEntryFlag('key', '')).toBeUndefined();
+    });
+
+    it('should return false if the value is not "true"', () => {
+        expect(getEnvEntryFlag('key', 'TRUE')).toEqual({key: false});
+        expect(getEnvEntryFlag('key', 'false')).toEqual({key: false});
+    });
+
+    it('should return the normalized value', () => {
+        expect(getEnvEntryFlag('key', 'true')).toEqual({key: true});
+    });
+});
+
+describe('getEnvValue', () => {
+    it('should return undefined if the value is undefined', () => {
+        expect(getEnvValue(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if the value is an empty string', () => {
+        expect(getEnvValue('')).toBeUndefined();
+    });
+
+    it('should return the value', () => {
+        expect(getEnvValue('value')).toBe('value');
+    });
+
+    it('should return the normalized value', () => {
+        expect(getEnvValue('value', (value = '') => value.toUpperCase())).toBe('VALUE');
+    });
+});
+
+describe('getEnvFlag', () => {
+    it('should return false if the value is not "true"', () => {
+        expect(getEnvFlag('TRUE')).toBe(false);
+        expect(getEnvFlag('false')).toBe(false);
+        expect(getEnvFlag(undefined)).toBe(false);
+    });
+
+    it('should return true if the value is "true"', () => {
+        expect(getEnvFlag('true')).toBe(true);
+    });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,44 @@
+type Normalizer<V, R> = (value: V) => R;
+
+export function getEnvValue(value: string|undefined): string|undefined;
+
+export function getEnvValue<V extends string|undefined, R>(value: V, normalize: Normalizer<V, R>): R;
+
+export function getEnvValue<V extends string|undefined, R>(
+    value: V,
+    normalize?: Normalizer<V, R>,
+): R|string|undefined {
+    if (normalize === undefined && (value === undefined || value === '')) {
+        return undefined;
+    }
+
+    return normalize !== undefined ? normalize(value) : value;
+}
+
+export function getEnvFlag(value: string|undefined): boolean {
+    return getEnvValue(value, flag => flag === 'true');
+}
+
+export function getEnvEntry<K extends string, V extends string|undefined>(key: K, value: V): Record<K, V>|undefined;
+
+export function getEnvEntry<K extends string, V extends string|undefined, R>(
+  key: K,
+  value: V,
+  normalize: Normalizer<V, R>,
+): Record<K, R>|undefined;
+
+export function getEnvEntry<K extends string, V extends string|undefined, R>(
+    key: K,
+    value: V,
+    normalize?: Normalizer<V, R>,
+): Record<string, R|string>|undefined {
+    if (value === undefined || value === '') {
+        return undefined;
+    }
+
+    return {[key]: normalize !== undefined ? normalize(value) : value};
+}
+
+export function getEnvEntryFlag(key: string, value: string|undefined): Record<string, boolean>|undefined {
+    return getEnvEntry(key, value, flag => flag === 'true');
+}

--- a/src/server/evaluate.ts
+++ b/src/server/evaluate.ts
@@ -6,6 +6,7 @@ import {getApiKey} from '@/config/security';
 import {RequestContext, resolveRequestContext} from '@/config/context';
 import {getDefaultFetchTimeout} from '@/config/timeout';
 import {isAppRouter, RouteContext} from '@/headers';
+import {getEnvEntry, getEnvFlag} from '@/config/env';
 
 export type EvaluationOptions<T extends JsonValue = JsonValue> = Omit<BaseOptions<T>, 'apiKey' | 'appId'> & {
     route?: RouteContext,
@@ -37,12 +38,17 @@ export function evaluate<T extends JsonValue>(query: string, options: Evaluation
         ...(context.userToken !== undefined && {userToken: context.userToken}),
         ...(context.clientId !== undefined && {clientId: context.clientId}),
         ...(context.clientAgent !== undefined && {clientAgent: context.clientAgent}),
+        ...getEnvEntry('baseEndpointUrl', process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL),
         timeout: getDefaultFetchTimeout(),
         extra: {
             cache: 'no-store',
         },
         ...rest,
-        logger: rest.logger ?? FilteredLogger.include(new ConsoleLogger(), ['warn', 'error']),
+        logger: rest.logger ?? (
+            getEnvFlag(process.env.NEXT_PUBLIC_CROCT_DEBUG)
+                ? new ConsoleLogger()
+                : FilteredLogger.include(new ConsoleLogger(), ['warn', 'error'])
+        ),
         ...(context.uri !== undefined
             ? {
                 context: {

--- a/src/server/fetchContent.ts
+++ b/src/server/fetchContent.ts
@@ -6,6 +6,7 @@ import {getApiKey} from '@/config/security';
 import {RequestContext, resolveRequestContext} from '@/config/context';
 import {getDefaultFetchTimeout} from '@/config/timeout';
 import {RouteContext} from '@/headers';
+import {getEnvEntry, getEnvFlag} from '@/config/env';
 
 export type FetchOptions<T extends JsonObject = JsonObject> = Omit<DynamicContentOptions<T>, 'apiKey' | 'appId'> & {
     route?: RouteContext,
@@ -52,12 +53,17 @@ export function fetchContent<I extends VersionedSlotId, C extends JsonObject>(
             }
             : {}
         ),
+        ...getEnvEntry('baseEndpointUrl', process.env.NEXT_PUBLIC_CROCT_BASE_ENDPOINT_URL),
         timeout: getDefaultFetchTimeout(),
         extra: {
             cache: 'no-store',
         },
         ...rest,
-        logger: rest.logger ?? FilteredLogger.include(new ConsoleLogger(), ['warn', 'error']),
+        logger: rest.logger ?? (
+            getEnvFlag(process.env.NEXT_PUBLIC_CROCT_DEBUG)
+                ? new ConsoleLogger()
+                : FilteredLogger.include(new ConsoleLogger(), ['warn', 'error'])
+        ),
     });
 
     return promise.then(({content}) => content);


### PR DESCRIPTION
## Summary
This PR makes the `fetchContent` and `evaluationContent` use applicable configurations from the environment variables.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings