### PR TITLE
Add automatic route location to hooks

### DIFF
--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,0 +1,3 @@
+export * from '@croct/plug-react/hooks/useEvaluation';
+export * from '@croct/plug-react/hooks/useCroct';
+export * from './useContent';

--- a/src/hooks/useContent.test.ts
+++ b/src/hooks/useContent.test.ts
@@ -1,0 +1,67 @@
+import {useContent as useContentMock} from '@croct/plug-react';
+import {type NextRouter, useRouter} from 'next/router';
+import {useContent, UseContentOptions} from '@/hooks/useContent';
+
+jest.mock(
+    '@croct/plug-react',
+    () => ({
+        useContent: jest.fn(),
+    }),
+);
+
+jest.mock(
+    'next/router',
+    () => ({
+        useRouter: jest.fn(() => ({locale: undefined})),
+    }),
+);
+
+describe('useContent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should forward the call to useContent', () => {
+        const content = {content: 'content'};
+
+        jest.mocked(useContentMock).mockReturnValue(content);
+
+        const options: UseContentOptions<any, any> = {preferredLocale: 'en'};
+
+        expect(useContent('id', options)).toBe(content);
+
+        expect(useContentMock).toHaveBeenCalledWith('id', options);
+    });
+
+    it('should use the locale from the router', () => {
+        jest.mocked(useContentMock).mockReturnValue({});
+
+        jest.mocked(useRouter).mockReturnValue({locale: 'en'} as NextRouter);
+
+        useContent('id');
+
+        expect(useContentMock).toHaveBeenCalledWith('id', {preferredLocale: 'en'});
+    });
+
+    it('should ignore empty locale', () => {
+        jest.mocked(useContentMock).mockReturnValue({});
+
+        jest.mocked(useRouter).mockReturnValue({locale: ''} as NextRouter);
+
+        useContent('id');
+
+        expect(useContentMock).toHaveBeenCalledWith('id', undefined);
+    });
+
+    it('should not override the specified locale', () => {
+        jest.mocked(useContentMock).mockReturnValue({});
+
+        jest.mocked(useRouter).mockReturnValue({locale: 'en'} as NextRouter);
+
+        const options: UseContentOptions<any, any> = {preferredLocale: 'de'};
+
+        useContent('id', options);
+
+        expect(useContentMock).toHaveBeenCalledWith('id', options);
+    });
+});

--- a/src/hooks/useContent.ts
+++ b/src/hooks/useContent.ts
@@ -1,0 +1,17 @@
+import {useContent as useContentReact, UseContentOptions, SlotContent, VersionedSlotId} from '@croct/plug-react';
+import {useRouter} from 'next/router';
+
+export type {UseContentOptions} from '@croct/plug-react';
+
+function useContentNext(id: VersionedSlotId, options?: UseContentOptions<any, any>): SlotContent {
+    const {locale = ''} = useRouter();
+
+    return useContentReact<any, any, any>(
+        id,
+        options?.preferredLocale === undefined && locale !== ''
+            ? {...options, preferredLocale: locale}
+            : options,
+    );
+}
+
+export const useContent: typeof useContentReact = useContentNext;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 export * from '@croct/plug/sdk/json';
 export * from '@croct/plug/slot';
 export * from '@croct/plug/component';
-export * from '@croct/plug-react/hooks';
 export * from '@croct/plug-react/components';
+export * from './hooks';


### PR DESCRIPTION
## Summary
This PR adds support for the `useContent` automatic detects the locale from the Next router.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings