### PR TITLE
Fix base 64 decoding

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -146,12 +146,11 @@ describe('middleware', () => {
         jest.useRealTimers();
     });
 
-    const previewToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2Nyb2N0LmlvIiwi'
-        + 'YXVkIjoiaHR0cHM6Ly9jcm9jdC5pbyIsImlhdCI6MTQ0MDk3OTEwMCwiZXhwIjoxNDQwOTc5M'
-        + 'jAwLCJtZXRhZGF0YSI6eyJleHBlcmllbmNlTmFtZSI6IkRldmVsb3BlcnMgZXhwZXJpZW5jZS'
-        + 'IsImV4cGVyaW1lbnROYW1lIjoiRGV2ZWxvcGVycyBleHBlcmltZW50IiwiYXVkaWVuY2VOYW1l'
-        + 'IjoiRGV2ZWxvcGVycyBhdWRpZW5jZSIsInZhcmlhbnROYW1lIjoiSmF2YVNjcmlwdCBEZXZlbG'
-        + '9wZXJzIn19.';
+    const previewToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2Nyb2N0LmlvIiwiYXVkIjoiaHR0cH'
+       + 'M6Ly9jcm9jdC5pbyIsImlhdCI6MTQ0MDk3OTEwMCwiZXhwIjoxNDQwOTc5MjAwLCJtZXRhZGF0YSI6eyJleHBlcmllbmN'
+       + 'lTmFtZSI6IkRldmVsb3BlcnMgZXhwZXJpZW5jZSIsImV4cGVyaW1lbnROYW1lIjoiRGV2ZWxvcGVycyBleHBlcmltZW50'
+       + 'IiwiYXVkaWVuY2VOYW1lIjoi8J-RqOKAjfCfkrsgRGV2ZWxvcGVycyBhdWRpZW5jZSIsInZhcmlhbnROYW1lIjoiSmF2Y'
+       + 'VNjcmlwdCBEZXZlbG9wZXJzIn19.ZmfcfhPoxFs0cY86ixGBCDab3rPSMoUG4cboWX0NEOY';
 
     const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,8 @@
-import {NextRequest, NextMiddleware, NextResponse} from 'next/server';
+import {NextMiddleware, NextRequest, NextResponse} from 'next/server';
 import cookie from 'cookie';
 import {v4 as uuidv4} from 'uuid';
 import {Token} from '@croct/sdk/token';
+import {base64UrlDecode} from '@croct/sdk/base64Url';
 import {Header, QueryParameter} from '@/config/http';
 import {
     CookieOptions,
@@ -181,7 +182,7 @@ function isPreviewTokenValid(token: unknown): token is string {
     const now = Math.floor(Date.now() / 1000);
 
     try {
-        const payload = JSON.parse(atob(token.split('.')[1]).toString());
+        const payload = JSON.parse(base64UrlDecode(token.split('.')[1]).toString());
 
         return Number.isInteger(payload.exp) && payload.exp > now;
     } catch {


### PR DESCRIPTION
## Summary
This PR fixes the base64 decoding to handle UTF-8 emojis, which prevents the plug from invalidating valid preview tokens.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings