### PR TITLE
Fix error propagation

### DIFF
--- a/src/headers.test.ts
+++ b/src/headers.test.ts
@@ -34,11 +34,24 @@ describe('getHeaders', () => {
     });
 
     it('should require the request context if next/headers is not available', () => {
+        const error = new Error('next/headers requires app router');
+
         mockHeaders.mockImplementation(() => {
-            throw new Error('next/headers requires app router');
+            throw error;
         });
 
-        expect(() => getHeaders()).toThrow('No route context found.');
+        let actualError: unknown;
+
+        try {
+            getHeaders();
+        } catch (caughtError) {
+            actualError = caughtError;
+        }
+
+        // Ensure it rethrows the exact same error.
+        // It is important because Next uses the error type to detect dynamic routes based
+        // on usage of headers or cookies
+        expect(actualError).toBe(error);
     });
 
     type RequestContextScenario = {
@@ -138,11 +151,24 @@ describe('getCookies', () => {
     });
 
     it('should require the request context if next/headers is not available', () => {
+        const error = new Error('next/headers requires app router');
+
         mockCookies.mockImplementation(() => {
-            throw new Error('next/headers requires app router');
+            throw error;
         });
 
-        expect(() => getCookies()).toThrow('No route context found.');
+        let actualError: unknown;
+
+        try {
+            getCookies();
+        } catch (caughtError) {
+            actualError = caughtError;
+        }
+
+        // Ensure it rethrows the exact same error.
+        // It is important because Next uses the error type to detect dynamic routes based
+        // on usage of headers or cookies
+        expect(actualError).toBe(error);
     });
 
     type RequestContextScenario = {

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -36,9 +36,9 @@ export function getHeaders(route?: RouteContext): HeaderReader {
         const {headers} = importNextHeaders();
 
         return headers();
-    } catch {
+    } catch (error) {
         if (route === undefined) {
-            throw new Error('No route context found.');
+            throw error;
         }
     }
 
@@ -70,9 +70,9 @@ export function getCookies(route?: RouteContext): CookieAccessor {
         const {cookies} = importNextHeaders();
 
         return cookies();
-    } catch {
+    } catch (error) {
         if (route === undefined) {
-            throw new Error('No route context found.');
+            throw error;
         }
     }
 


### PR DESCRIPTION
## Summary
Next.js uses an exception-based mechanism to determine whether a route is dynamic. For instance, when cookies or headers are accessed within a static route, a `DynamicServerError` is triggered, which disables static generation for that route.

However, since this error is currently being caught for error reporting purposes, Next.js fails to detect dynamic hook usage correctly, resulting in a build failure.

This PR addresses the issue by allowing these errors to propagate up the call stack, enabling accurate detection of dynamic hooks and ensuring the build process succeeds.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings