### PR TITLE
Fix compatibility with page and app router

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,47 @@
+import {isDynamicServerError} from '@/errors';
+
+describe('errors', () => {
+    type TypeGuardScenario = {
+        error: any,
+        expected: boolean,
+    };
+
+    it.each<TypeGuardScenario>([
+        {
+            error: null,
+            expected: false,
+        },
+        {
+            error: undefined,
+            expected: false,
+        },
+        {
+            error: {},
+            expected: false,
+        },
+        {
+            error: new Error(),
+            expected: false,
+        },
+        {
+            error: new class {
+                public readonly digest = 'DYNAMIC_SERVER_USAGE';
+            }(),
+            expected: false,
+        },
+        {
+            error: new class DynamicServerError {
+                public readonly digest = 'foo';
+            }(),
+            expected: false,
+        },
+        {
+            error: new class DynamicServerError {
+                public readonly digest = 'DYNAMIC_SERVER_USAGE';
+            }(),
+            expected: true,
+        },
+    ])('should return $expected for $error identifying a DynamicServerError', ({error, expected}) => {
+        expect(isDynamicServerError(error)).toBe(expected);
+    });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,11 @@
+export declare class DynamicServerError extends Error {
+    public readonly digest = 'DYNAMIC_SERVER_USAGE';
+}
+
+export function isDynamicServerError(error: unknown): error is DynamicServerError {
+    return typeof error === 'object'
+        && error !== null
+        && error.constructor.name === 'DynamicServerError'
+        && 'digest' in error
+        && error.digest === 'DYNAMIC_SERVER_USAGE';
+}

--- a/src/hooks/useContent.test.ts
+++ b/src/hooks/useContent.test.ts
@@ -53,6 +53,18 @@ describe('useContent', () => {
         expect(useContentMock).toHaveBeenCalledWith('id', undefined);
     });
 
+    it('should ignore router errors', () => {
+        jest.mocked(useContentMock).mockReturnValue({});
+
+        jest.mocked(useRouter).mockImplementation(() => {
+            throw new Error();
+        });
+
+        useContent('id');
+
+        expect(useContentMock).toHaveBeenCalledWith('id', undefined);
+    });
+
     it('should not override the specified locale', () => {
         jest.mocked(useContentMock).mockReturnValue({});
 

--- a/src/hooks/useContent.ts
+++ b/src/hooks/useContent.ts
@@ -1,5 +1,5 @@
 import {useContent as useContentReact, UseContentOptions, SlotContent, VersionedSlotId} from '@croct/plug-react';
-import {useRouter} from 'next/router';
+import {NextRouter, useRouter as usePageRouter} from 'next/router';
 
 export type {UseContentOptions} from '@croct/plug-react';
 
@@ -12,6 +12,14 @@ function useContentNext(id: VersionedSlotId, options?: UseContentOptions<any, an
             ? {...options, preferredLocale: locale}
             : options,
     );
+}
+
+export function useRouter(): Pick<NextRouter, 'locale'> {
+    try {
+        return usePageRouter();
+    } catch {
+        return {};
+    }
 }
 
 export const useContent: typeof useContentReact = useContentNext;

--- a/src/server/evaluate.ts
+++ b/src/server/evaluate.ts
@@ -3,12 +3,12 @@ import type {JsonValue} from '@croct/plug-react';
 import {FilteredLogger} from '@croct/sdk/logging/filteredLogger';
 import {ConsoleLogger} from '@croct/sdk/logging/consoleLogger';
 import {formatCause} from '@croct/sdk/error';
-import {isDynamicServerError} from 'next/dist/client/components/hooks-server-context';
 import {getApiKey} from '@/config/security';
 import {RequestContext, resolveRequestContext} from '@/config/context';
 import {getDefaultFetchTimeout} from '@/config/timeout';
 import {isAppRouter, RouteContext} from '@/headers';
 import {getEnvEntry, getEnvFlag} from '@/config/env';
+import {isDynamicServerError} from '@/errors';
 
 export type EvaluationOptions<T extends JsonValue = JsonValue> = Omit<BaseOptions<T>, 'apiKey' | 'appId'> & {
     route?: RouteContext,

--- a/src/server/fetchContent.test.ts
+++ b/src/server/fetchContent.test.ts
@@ -4,7 +4,6 @@ import {FetchResponse} from '@croct/plug/plug';
 import {ApiKey, ApiKey as MockApiKey} from '@croct/sdk/apiKey';
 import {FilteredLogger} from '@croct/sdk/logging/filteredLogger';
 import type {NextRequest, NextResponse} from 'next/server';
-import {DynamicServerError} from 'next/dist/client/components/hooks-server-context';
 import {fetchContent, FetchOptions} from './fetchContent';
 import {RequestContext, resolvePreferredLocale, resolveRequestContext} from '@/config/context';
 import {getDefaultFetchTimeout} from '@/config/timeout';
@@ -291,7 +290,15 @@ describe('fetchContent', () => {
     });
 
     it('should rethrow dynamic server errors', async () => {
-        const error = new DynamicServerError('cause');
+        const error = new class DynamicServerError extends Error {
+            public readonly digest = 'DYNAMIC_SERVER_USAGE';
+
+            public constructor() {
+                super('cause');
+
+                Object.setPrototypeOf(this, new.target.prototype);
+            }
+        }();
 
         jest.mocked(resolveRequestContext).mockImplementation(() => {
             throw error;

--- a/src/server/fetchContent.ts
+++ b/src/server/fetchContent.ts
@@ -8,12 +8,12 @@ import type {SlotContent, VersionedSlotId, JsonObject} from '@croct/plug-react';
 import {FilteredLogger} from '@croct/sdk/logging/filteredLogger';
 import {ConsoleLogger} from '@croct/sdk/logging/consoleLogger';
 import {formatCause} from '@croct/sdk/error';
-import {isDynamicServerError} from 'next/dist/client/components/hooks-server-context';
 import {getApiKey} from '@/config/security';
 import {RequestContext, resolvePreferredLocale, resolveRequestContext} from '@/config/context';
 import {getDefaultFetchTimeout} from '@/config/timeout';
 import {RouteContext} from '@/headers';
 import {getEnvEntry, getEnvFlag} from '@/config/env';
+import {isDynamicServerError} from '@/errors';
 
 export type DynamicContentOptions<T extends JsonObject = JsonObject> = Omit<DynamicOptions<T>, 'apiKey' | 'appId'>;
 


### PR DESCRIPTION
## Summary

This PR addresses two issues:

Compatibility with next/dist imports: In certain applications, the SDK could not import classes from next/dist. To resolve this, the logic has been moved directly into the SDK.
Hook compatibility with App Router: The hook was failing when used with the App Router because it was relying on the useRouter implementation compatible only with the Page Router. This has been updated to properly check and ensure compatibility, preventing errors.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings