### PR TITLE
Fix error type guard

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -27,18 +27,6 @@ describe('errors', () => {
             error: new class {
                 public readonly digest = 'DYNAMIC_SERVER_USAGE';
             }(),
-            expected: false,
-        },
-        {
-            error: new class DynamicServerError {
-                public readonly digest = 'foo';
-            }(),
-            expected: false,
-        },
-        {
-            error: new class DynamicServerError {
-                public readonly digest = 'DYNAMIC_SERVER_USAGE';
-            }(),
             expected: true,
         },
     ])('should return $expected for $error identifying a DynamicServerError', ({error, expected}) => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,7 +5,6 @@ export declare class DynamicServerError extends Error {
 export function isDynamicServerError(error: unknown): error is DynamicServerError {
     return typeof error === 'object'
         && error !== null
-        && error.constructor.name === 'DynamicServerError'
         && 'digest' in error
         && error.digest === 'DYNAMIC_SERVER_USAGE';
 }


### PR DESCRIPTION
## Summary
Fix type guard to rely on the digest property instead of the error name, as the error name changes after modification.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings