### PR TITLE
Fix middleware chaining

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1147,6 +1147,8 @@ describe('middleware', () => {
         const request = createRequestMock();
         const response = createResponseMock();
 
+        request.headers.set('x-custom-header', 'custom-value');
+
         const nextResponse = NextResponse.next;
 
         const spy = jest.spyOn(NextResponse, 'next').mockReturnValue(response);
@@ -1168,6 +1170,8 @@ describe('middleware', () => {
         const headers = spy.mock.calls[0][0]?.request?.headers;
 
         expect(headers?.get(Header.CLIENT_ID)).not.toBeNull();
+
+        expect(headers?.get('x-custom-header')).toBe('custom-value');
 
         expect(nextResponse).toBe(NextResponse.next);
     });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -263,11 +263,9 @@ async function handleRequest(
     NextResponse.next = ({request: modifiedRequest = {}, ...init} = {}): NextResponse => {
         const mergedHeaders = new Headers(request.headers);
 
-        if (modifiedRequest.headers !== undefined) {
-            modifiedRequest.headers.forEach((value, name) => {
-                mergedHeaders.set(name, value);
-            });
-        }
+        modifiedRequest.headers?.forEach((value, name) => {
+            mergedHeaders.set(name, value);
+        });
 
         return nextResponse({
             ...init,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -260,17 +260,19 @@ async function handleRequest(
 
     const nextResponse = NextResponse.next;
 
-    NextResponse.next = (init): NextResponse => {
-        const mergedHeaders = new Headers(init?.request?.headers);
+    NextResponse.next = ({request: modifiedRequest = {}, ...init} = {}): NextResponse => {
+        const mergedHeaders = new Headers(request.headers);
 
-        headers.forEach((value, name) => {
-            mergedHeaders.set(name, value);
-        });
+        if (modifiedRequest.headers !== undefined) {
+            modifiedRequest.headers.forEach((value, name) => {
+                mergedHeaders.set(name, value);
+            });
+        }
 
         return nextResponse({
             ...init,
             request: {
-                ...init?.request,
+                ...modifiedRequest,
                 headers: mergedHeaders,
             },
         });


### PR DESCRIPTION
## Summary
The current middleware does not forward the original request headers, which can cause unexpected behavior when fetching content.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings