### PR TITLE
Remove matcher exports

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -4,9 +4,8 @@ import parseSetCookies, {Cookie} from 'set-cookie-parser';
 import {Token} from '@croct/sdk/token';
 import {ApiKey} from '@croct/sdk/apiKey';
 import {ipAddress} from '@vercel/functions';
-import {pathToRegexp} from 'path-to-regexp';
 import {Header, QueryParameter} from '@/config/http';
-import {config, matcher, withCroct} from '@/middleware';
+import {withCroct} from '@/middleware';
 import {getAppId} from '@/config/appId';
 import {RouterCriteria} from '@/matcher';
 
@@ -34,30 +33,6 @@ jest.mock(
         ipAddress: jest.fn(),
     }),
 );
-
-describe('matcher', () => {
-    it.each<string>([
-        '/foo',
-        '/foo/bar',
-        '/foo/bar/baz',
-        '/foo/bar/baz/qux',
-    ])('should intercept requests to "%s"', path => {
-        expect(config.matcher).toHaveLength(1);
-        expect(path).toMatch(pathToRegexp(matcher.source));
-    });
-
-    it.each<string>([
-        '/api',
-        '/_next/static',
-        '/_next/image',
-        '/favicon.ico',
-        '/sitemap.xml',
-        '/robots.txt',
-    ])('should not intercept requests to "%s"', path => {
-        expect(config.matcher).toHaveLength(1);
-        expect(path).not.toMatch(pathToRegexp(matcher.source));
-    });
-});
 
 describe('middleware', () => {
     const ENV_VARS = {...process.env};
@@ -1108,8 +1083,6 @@ describe('middleware', () => {
     it('should call the next middleware if the matcher matches regardless of the request URL', async () => {
         const request = createRequestMock(new URL('https://example.com/api/foo'));
         const response = createResponseMock();
-
-        expect(request.nextUrl.pathname).not.toMatch(new RegExp(`^${matcher.source}$`));
 
         const nextMiddleware = jest.fn().mockResolvedValue(response);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,22 +17,6 @@ import {createMatcher, RouterCriteria} from '@/matcher';
 const matcherRegex = /\/((?!api|_next\/static|_next\/image|favicon\.ico|sitemap\.xml|robots\.txt).*)/;
 const isPageRoute = createMatcher([{source: matcherRegex.source}]);
 
-export const matcher = {
-    /*
-     * Match all request paths except for the ones starting with:
-     *
-     * - api (API routes)
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
-     */
-    source: matcherRegex.source,
-} satisfies RouterCriteria;
-
-export const config = {
-    matcher: [matcher],
-};
-
 const CLIENT_ID_PATTERN = /^(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[a-f0-9]{32})$/;
 
 export const middleware = withCroct();
@@ -57,7 +41,7 @@ type CroctMiddlewareParams =
 
 export function withCroct(): NextMiddleware;
 export function withCroct(next: NextMiddleware): NextMiddleware;
-// eslint-disable-next-line @typescript-eslint/no-shadow -- False positive
+
 export function withCroct(next: NextMiddleware, matcher: MiddlewareMatcher): NextMiddleware;
 export function withCroct(props: CroctMiddlewareOptions): NextMiddleware;
 


### PR DESCRIPTION
## Summary
This PR removes the exported matchers as Next.js doesn't support it.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings