### PR TITLE
Improve IP extraction from request headers in middleware

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -411,13 +411,76 @@ describe('middleware', () => {
         expect(request.headers.get(Header.USER_AGENT)).toBe(userAgent);
     });
 
-    it('should forward the client IP through the request headers', async () => {
+    it('should forward the client IP from the ipAddress through the request headers', async () => {
         const request = createRequestMock();
         const response = createResponseMock();
 
         const ip = '127.0.0.1';
 
         jest.mocked(ipAddress).mockReturnValue(ip);
+
+        jest.spyOn(NextResponse, 'next').mockReturnValue(response);
+
+        const nextMiddleware = jest.fn().mockResolvedValue(response);
+
+        await expect(withCroct(nextMiddleware)(request, fetchEvent)).resolves.toBe(response);
+
+        expect(nextMiddleware).toHaveBeenCalledWith(request, fetchEvent);
+
+        expect(ipAddress).toHaveBeenCalledWith(request);
+
+        expect(request.headers.get(Header.CLIENT_IP)).toBe(ip);
+    });
+
+    it('should forward the client IP from the x-real-ip header through the request headers', async () => {
+        const request = createRequestMock();
+        const response = createResponseMock();
+
+        const ip = '127.0.0.1';
+
+        request.headers.set('x-real-ip', ip);
+
+        jest.spyOn(NextResponse, 'next').mockReturnValue(response);
+
+        const nextMiddleware = jest.fn().mockResolvedValue(response);
+
+        await expect(withCroct(nextMiddleware)(request, fetchEvent)).resolves.toBe(response);
+
+        expect(nextMiddleware).toHaveBeenCalledWith(request, fetchEvent);
+
+        expect(ipAddress).toHaveBeenCalledWith(request);
+
+        expect(request.headers.get(Header.CLIENT_IP)).toBe(ip);
+    });
+
+    it('should forward the client IP from the x-forwarded-for header through the request headers', async () => {
+        const request = createRequestMock();
+        const response = createResponseMock();
+
+        const ip = '127.0.0.1';
+
+        request.headers.set('x-forwarded-for', ip);
+
+        jest.spyOn(NextResponse, 'next').mockReturnValue(response);
+
+        const nextMiddleware = jest.fn().mockResolvedValue(response);
+
+        await expect(withCroct(nextMiddleware)(request, fetchEvent)).resolves.toBe(response);
+
+        expect(nextMiddleware).toHaveBeenCalledWith(request, fetchEvent);
+
+        expect(ipAddress).toHaveBeenCalledWith(request);
+
+        expect(request.headers.get(Header.CLIENT_IP)).toBe(ip);
+    });
+
+    it('should forward the client IP from the first x-forwarded-for header through the request headers', async () => {
+        const request = createRequestMock();
+        const response = createResponseMock();
+
+        const ip = '127.0.0.1';
+
+        request.headers.set('x-forwarded-for', `${ip},192.168.0.2`);
 
         jest.spyOn(NextResponse, 'next').mockReturnValue(response);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -92,9 +92,15 @@ export function withCroct(...args: CroctMiddlewareParams): NextMiddleware {
             headers.set(Header.PREFERRED_LOCALE, locale);
         }
 
-        const ip = ipAddress(request);
+        const ip = ipAddress(request)
+            ?? request.headers
+                .get('x-forwarded-for')
+                ?.split(',')[0]
+                .trim()
+            ?? request.headers.get('x-real-ip')
+            ?? null;
 
-        if (ip !== undefined) {
+        if (ip !== null) {
             headers.set(Header.CLIENT_IP, ip);
         }
 


### PR DESCRIPTION
## Summary

This pull request enhances how client IP addresses are extracted and forwarded in the middleware, improving support for common proxy headers and strengthening test coverage for these scenarios.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings