### PR TITLE
Fix token ID propagation

### DIFF
--- a/src/config/security.test.ts
+++ b/src/config/security.test.ts
@@ -222,6 +222,58 @@ describe('security', () => {
             await expect(verification).resolves.toBeTrue();
         });
 
+        it('should preserve a given token ID when issuing a signed token', async () => {
+            jest.useFakeTimers({now: Date.now()});
+
+            const keyPair = await crypto.subtle.generateKey(
+                {
+                    name: 'ECDSA',
+                    namedCurve: 'P-256',
+                },
+                true,
+                ['sign', 'verify'],
+            );
+
+            const localPrivateKey = Buffer.from(await crypto.subtle.exportKey('pkcs8', keyPair.privateKey))
+                .toString('base64');
+
+            const apiKey = MockApiKey.of('00000000-0000-0000-0000-000000000001', `ES256;${localPrivateKey}`);
+
+            process.env.NEXT_PUBLIC_CROCT_APP_ID = '00000000-0000-0000-0000-000000000000';
+            process.env.CROCT_API_KEY = apiKey.export();
+            process.env.CROCT_TOKEN_DURATION = '3600';
+            process.env.CROCT_DISABLE_USER_TOKEN_AUTHENTICATION = 'false';
+
+            const tokenId = '11111111-2222-3333-4444-555555555555';
+
+            const token = await issueToken('user-id', tokenId);
+
+            expect(token.getTokenId()).toBe(tokenId);
+            expect(token.getSubject()).toBe('user-id');
+            expect(token.getPayload()).toEqual({
+                iat: Math.floor(Date.now() / 1000),
+                exp: Math.floor(Date.now() / 1000) + 3600,
+                iss: 'croct.io',
+                aud: 'croct.io',
+                sub: 'user-id',
+                jti: tokenId,
+            });
+        });
+
+        it('should ignore the token ID when authentication is disabled', async () => {
+            jest.useFakeTimers({now: Date.now()});
+
+            process.env.NEXT_PUBLIC_CROCT_APP_ID = '00000000-0000-0000-0000-000000000000';
+            process.env.CROCT_API_KEY = `${identifier}:${privateKey}`;
+            process.env.CROCT_DISABLE_USER_TOKEN_AUTHENTICATION = 'true';
+            process.env.CROCT_TOKEN_DURATION = '3600';
+
+            const token = await issueToken('user-id', '11111111-2222-3333-4444-555555555555');
+
+            expect(token.getTokenId()).toBeNull();
+            expect(token.getSignature()).toBe('');
+        });
+
         it.each<[string, string | undefined]>([
             ['an anonymous user', undefined],
             ['an identified user', 'user-id'],

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -73,12 +73,12 @@ export function getTokenDuration(): number {
 /**
  * @internal
  */
-export function issueToken(userId: string | null = null): Promise<Token> {
+export function issueToken(userId: string | null = null, tokenId?: string): Promise<Token> {
     const token = Token.issue(getAppId(), userId)
         .withDuration(getTokenDuration());
 
     if (isUserTokenAuthenticationEnabled()) {
-        return token.withTokenId(crypto.randomUUID())
+        return token.withTokenId(tokenId ?? crypto.randomUUID())
             .signedWith(getAuthenticationKey());
     }
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -747,6 +747,8 @@ describe('proxy', () => {
         currentUserId?: string | null,
         requestToken?: {
             apiKey?: string,
+            appId?: string,
+            tokenId?: string,
             userId: string | null,
             expiration: number,
             issueTime: number,
@@ -754,6 +756,10 @@ describe('proxy', () => {
         },
         expectTokenChange: boolean,
         expectSignedToken: boolean,
+        expectTokenId?: 'preserved' | 'fresh',
+        expectSubject?: string | null,
+        expectIssueTime?: number,
+        expectExpirationTime?: number,
     };
 
     it.each<[string, UserTokenChangeScenario]>(
@@ -900,7 +906,43 @@ describe('proxy', () => {
                 expectTokenChange: true,
                 expectSignedToken: false,
             },
-            'a new authenticated token if the API key changes': {
+            'a re-signed token with preserved jti, sub and refreshed iat if only the API key changes': {
+                now: 1714881454,
+                authentication: true,
+                currentApiKey: '00000000-0000-0000-0000-000000000002',
+                currentUserId: '00000000-0000-0000-0000-000000000001',
+                requestToken: {
+                    expiration: 1714881454 + 1000,
+                    issueTime: 1714881454 - 60,
+                    userId: '00000000-0000-0000-0000-000000000001',
+                    apiKey: '00000000-0000-0000-0000-000000000001',
+                    tokenId: '11111111-1111-1111-1111-111111111111',
+                    signed: true,
+                },
+                expectTokenChange: true,
+                expectSignedToken: true,
+                expectTokenId: 'preserved',
+                expectIssueTime: 1714881454,
+                expectExpirationTime: 1714881454 + 86400,
+            },
+            'a re-signed token with preserved sub if the API key changes and no resolver is provided': {
+                now: 1714881454,
+                authentication: true,
+                currentApiKey: '00000000-0000-0000-0000-000000000002',
+                requestToken: {
+                    expiration: 1714881454 + 1000,
+                    issueTime: 1714881454,
+                    userId: '00000000-0000-0000-0000-000000000001',
+                    apiKey: '00000000-0000-0000-0000-000000000001',
+                    tokenId: '22222222-2222-2222-2222-222222222222',
+                    signed: true,
+                },
+                expectTokenChange: true,
+                expectSignedToken: true,
+                expectTokenId: 'preserved',
+                expectSubject: '00000000-0000-0000-0000-000000000001',
+            },
+            'a fresh token if both the API key and the application ID change': {
                 now: 1714881454,
                 authentication: true,
                 currentApiKey: '00000000-0000-0000-0000-000000000002',
@@ -910,10 +952,30 @@ describe('proxy', () => {
                     issueTime: 1714881454,
                     userId: '00000000-0000-0000-0000-000000000001',
                     apiKey: '00000000-0000-0000-0000-000000000001',
+                    appId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+                    tokenId: '33333333-3333-3333-3333-333333333333',
                     signed: true,
                 },
                 expectTokenChange: true,
                 expectSignedToken: true,
+                expectTokenId: 'fresh',
+            },
+            'a fresh anonymous token if the application ID changes and no resolver is provided': {
+                now: 1714881454,
+                authentication: true,
+                requestToken: {
+                    expiration: 1714881454 + 1000,
+                    issueTime: 1714881454,
+                    userId: '00000000-0000-0000-0000-000000000001',
+                    apiKey: '00000000-0000-0000-0000-000000000001',
+                    appId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+                    tokenId: '44444444-4444-4444-4444-444444444444',
+                    signed: true,
+                },
+                expectTokenChange: true,
+                expectSignedToken: true,
+                expectTokenId: 'fresh',
+                expectSubject: null,
             },
             'a new authenticated token if the token is unauthenticated': {
                 now: 1714881454,
@@ -1072,7 +1134,7 @@ describe('proxy', () => {
             ? Token.of(
                 {
                     typ: 'JWT',
-                    appId: getAppId(),
+                    appId: requestToken.appId ?? getAppId(),
                     alg: 'none',
                 },
                 {
@@ -1086,7 +1148,7 @@ describe('proxy', () => {
             : null;
 
         const oldUserToken = oldUnsignedToken !== null && requestToken?.signed === true
-            ? await oldUnsignedToken.withTokenId(crypto.randomUUID())
+            ? await oldUnsignedToken.withTokenId(requestToken.tokenId ?? crypto.randomUUID())
                 .signedWith(oldApiKey)
             : oldUnsignedToken;
 
@@ -1110,12 +1172,36 @@ describe('proxy', () => {
 
         const parsedToken = Token.parse(newUserToken!);
 
+        const freshJtiMatcher = expect.not.stringMatching(requestToken?.tokenId ?? '\0');
+        const tokenIdMatchers: Record<'preserved' | 'fresh', unknown> = {
+            preserved: requestToken?.tokenId,
+            fresh: freshJtiMatcher,
+        };
+        const expectedJti = scenario.expectTokenId !== undefined ? tokenIdMatchers[scenario.expectTokenId] : undefined;
+
+        const expectedPayload: Record<string, unknown> = {};
+
+        if (expectedJti !== undefined) {
+            expectedPayload.jti = expectedJti;
+        }
+
+        if (scenario.expectIssueTime !== undefined) {
+            expectedPayload.iat = scenario.expectIssueTime;
+        }
+
+        if (scenario.expectExpirationTime !== undefined) {
+            expectedPayload.exp = scenario.expectExpirationTime;
+        }
+
+        const fallbackSubject = scenario.currentUserId !== undefined
+            ? scenario.currentUserId
+            : requestToken?.userId ?? null;
+
+        const expectedSubject = scenario.expectSubject !== undefined ? scenario.expectSubject : fallbackSubject;
+
         expect(parsedToken.isSigned()).toBe(scenario.expectSignedToken);
-        expect(parsedToken.getSubject()).toBe(
-            scenario.currentUserId !== undefined
-                ? scenario.currentUserId
-                : requestToken?.userId ?? null,
-        );
+        expect(parsedToken.getSubject()).toBe(expectedSubject);
+        expect(parsedToken.getPayload()).toEqual(expect.objectContaining(expectedPayload));
 
         expect(parseSetCookies(response.headers.getSetCookie())).toIncludeAllMembers([{
             name: cookieName,
@@ -1125,6 +1211,42 @@ describe('proxy', () => {
             sameSite: 'None',
             value: newUserToken,
         }]);
+    });
+
+    it('should re-sign a same-app token without jti when only the API key changes', async () => {
+        const privateKey = 'ES256;MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg3TbbvRM7DNwxY3XGWDmlSRPSfZ9b+ch9TO3'
+            + 'jQ68Zyj+hRANCAASmJj/EiEhUaLAWnbXMTb/85WADkuFgoELGZ5ByV7YPlbb2wY6oLjzGkpF6z8iDrvJ4kV6EhaJ4n0HwSQckVLNE';
+        const oldApiKey = ApiKey.of('00000000-0000-0000-0000-000000000001', privateKey);
+        const currentApiKey = ApiKey.of('00000000-0000-0000-0000-000000000002', privateKey);
+
+        jest.useFakeTimers({now: 1714881454 * 1000});
+
+        setEnvVars({
+            appId: '00000000-0000-0000-0000-000000000001',
+            apiKey: currentApiKey.export(),
+            enableTokenAuthentication: true,
+        });
+
+        const oldUnsignedToken = Token.of(
+            {typ: 'JWT', appId: getAppId(), alg: 'none'},
+            {iat: 1714881454, exp: 1714881454 + 1000, iss: 'test', aud: 'test', sub: 'user-1'},
+        );
+        const oldUserToken = await oldUnsignedToken.signedWith(oldApiKey);
+
+        expect(oldUserToken.getTokenId()).toBeNull();
+
+        const request = createRequestMock();
+        const response = createResponseMock();
+
+        request.cookies.set('ct.user_token', oldUserToken.toString());
+        jest.spyOn(NextResponse, 'next').mockReturnValue(response);
+
+        await expect(withCroct()(request, fetchEvent)).resolves.toBe(response);
+
+        const newToken = Token.parse(request.headers.get(Header.USER_TOKEN)!);
+
+        expect(newToken.getSubject()).toBe('user-1');
+        expect(newToken.getTokenId()).toMatch(UUID_PATTERN);
     });
 
     it('should use the locale resolver to determine the preferred locale', async () => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ import {Header, QueryParameter} from '@/config/http';
 import type {CookieOptions} from '@/config/cookie';
 import {getClientIdCookieOptions, getPreviewCookieOptions, getUserTokenCookieOptions} from '@/config/cookie';
 import {getAuthenticationKey, issueToken, isUserTokenAuthenticationEnabled} from './config/security';
+import {getAppId} from '@/config/appId';
 import type {RouterCriteria} from '@/matcher';
 import {createMatcher} from '@/matcher';
 
@@ -162,9 +163,21 @@ async function getUserToken(
         || (isUserTokenAuthenticationEnabled() && !token.isSigned())
         || !token.isValidNow()
         || (userId !== undefined && (userId === null ? !token.isAnonymous() : !token.isSubject(userId)))
-        || (token.isSigned() && !await token.matchesKeyId(getAuthenticationKey()))
     ) {
         return issueToken(userId);
+    }
+
+    const tokenAppId = token.getApplicationId();
+
+    if (tokenAppId !== null && tokenAppId !== getAppId()) {
+        // Foreign-app cookie pollution: fresh everything.
+        return issueToken(userId);
+    }
+
+    if (token.isSigned() && !await token.matchesKeyId(getAuthenticationKey())) {
+        // Same app, signed using a different API key. Re-sign with the local key but inherit
+        // jti and sub so the session continuity is preserved
+        return issueToken(userId ?? token.getSubject(), token.getTokenId() ?? undefined);
     }
 
     return token;


### PR DESCRIPTION
## Summary

The proxy was issuing a new user token JWT every time a user crossed between two Next.js app with different API keys. From the analytics side it looked like the user kept getting a fresh identity, even when nothing about them had actually changed. The cause was the regeneration gate in middleware: whenever the cookie was signed by a different API key than the local one, the token got wiped entirely. New `jti`, new `iat`, and if no `userIdResolver` was configured, the subject was dropped too. Sibling deployments that share a cookie domain but use different keys hit this on every cross-deployment hop.

This PR splits that gate into two cases. If the token belongs to a different `appId` (cookie pollution from an unrelated workspace), it still gets wiped completely. If it belongs to the same `appId` but was signed by a different key (the sibling deployment case), the proxy now re-signs the token with the local key while keeping the existing `jti` and `sub`. Only `iat`, `exp`, and the signature are refreshed. `

The result is a stable session continuity for the user across the whole cross-app journey, without weakening the kid security boundary. Each deployment still signs with its own key, so old or revoked tokens still get rolled forward on the next request. 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings